### PR TITLE
Ignore Cargo.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ nickel-test
 doc
 .DS_Store
 /target/
+Cargo.lock


### PR DESCRIPTION
Cargo has introduced the Cargo.lock file. This should be ignored :)
