### PR TITLE
=BG= fn delete should use http::method::Delete

### DIFF
--- a/src/nickel.rs
+++ b/src/nickel.rs
@@ -123,7 +123,7 @@ impl Nickel {
     /// ```
     /// Take a look at `get(...)` for a more detailed description.
     pub fn delete(&mut self, uri: &str, handler: fn(request: &Request, response: &mut Response)){
-        self.router.add_route(method::Put, String::from_str(uri), handler);
+        self.router.add_route(method::Delete, String::from_str(uri), handler);
     }
 
     /// Registers a middleware handler which will be invoked among other middleware


### PR DESCRIPTION
This is the enum: https://github.com/chris-morgan/rust-http/blob/8c8064affd7d20230a86e4886fb93abf96671a3a/src/http/method.rs#L14
