### PR TITLE
Remove dup impl sections for static file handler

### DIFF
--- a/src/static_files_handler.rs
+++ b/src/static_files_handler.rs
@@ -17,31 +17,6 @@ pub struct StaticFilesHandler {
     root_path: Path
 }
 
-impl StaticFilesHandler {
-    fn extract_path(&self, req: &mut request::Request) -> Option<String> {
-        match req.origin.request_uri {
-            AbsolutePath(ref path) => {
-                println!("{} {}{}",req.origin.method, from_utf8(self.root_path.container_as_bytes()).unwrap(), path); 
-                let mut relative_path = path.clone();
-                if relative_path.eq(&"/".to_string()) {
-                    relative_path = "index.html".to_string();
-                } else {
-                    relative_path.shift_char();
-                }
-                Some(relative_path)
-            }
-            _ => None
-        }
-    }
-
-    fn with_file(&self, relative_path: Option<String>, res: &mut response::Response) -> IoResult<()> {
-        match relative_path {
-            Some(path) => res.send_file(&self.root_path.join(Path::new(path))),
-            None => Err(IoError::last_error())
-        }
-    }
-}
-
 impl Middleware for StaticFilesHandler {
     fn invoke (&self, req: &mut request::Request, res: &mut response::Response) -> Action {
         match req.origin.method {
@@ -67,6 +42,29 @@ impl StaticFilesHandler {
         let checked_path = Path::new(root_path);
         StaticFilesHandler {
             root_path: checked_path
+        }
+    }
+
+    fn extract_path(&self, req: &mut request::Request) -> Option<String> {
+        match req.origin.request_uri {
+            AbsolutePath(ref path) => {
+                println!("{} {}{}",req.origin.method, from_utf8(self.root_path.container_as_bytes()).unwrap(), path);
+                let mut relative_path = path.clone();
+                if relative_path.eq(&"/".to_string()) {
+                    relative_path = "index.html".to_string();
+                } else {
+                    relative_path.shift_char();
+                }
+                Some(relative_path)
+            }
+            _ => None
+        }
+    }
+
+    fn with_file(&self, relative_path: Option<String>, res: &mut response::Response) -> IoResult<()> {
+        match relative_path {
+            Some(path) => res.send_file(&self.root_path.join(Path::new(path))),
+            None => Err(IoError::last_error())
         }
     }
 }


### PR DESCRIPTION
I didn't see that there was an `impl StaticFilesHandler` on the end of the file and opened up another one when working on the static files handler, this PR groups everything in just one impl section.
