### PR TITLE
Fix up the "import conflicts" error of server module.

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -1,7 +1,7 @@
 use std::io::net::ip::{SocketAddr, IpAddr, Port};
 
-use http;
-use http::server::{Config, Server, Request, ResponseWriter};
+use http::server::{Config, Request, ResponseWriter};
+use http::server::Server as HttpServer;
 
 use middleware::MiddlewareStack;
 use request;
@@ -14,7 +14,7 @@ pub struct Server {
     port: Port
 }
 
-impl http::server::Server for Server {
+impl HttpServer for Server {
     fn get_config(&self) -> Config {
         Config { bind_address: SocketAddr { ip: self.ip, port: self.port } }
     }


### PR DESCRIPTION
Hi @nickel-org,

I found that `use http::server::{..., Server, ...}` will cause a compiling error which said:

```
src/server.rs:3:28: 3:34 error: import conflicts with type in this module
src/server.rs:3 use http::server::{Config, Server, Request, ResponseWriter};
                                           ^~~~~~
src/server.rs:31:1: 44:2 note: note conflicting type here
```

And with the `impl http::server::Server for Server` usage, another error will be raised:

```
src/server.rs:43:14: 43:29 error: type `server::Server` does not implement any method in scope named `serve_forever`
src/server.rs:43         self.serve_forever();
```

It seems the reason is that only `use path::Trait` can pull the implementations into the current scope, which was mentioned [here](https://github.com/rust-lang/rust/issues/11690).

My patch resolved the two issues and it works with `rustc 0.12.0-pre-nightly (01ec6fab2 2014-08-18 00:46:10 +0000)` and `cargo 0.0.1-pre-nightly (b9c2abf 2014-08-16 19:44:14 +0000)`.
