### PR TITLE
Add implicit optional format param to routes

### DIFF
--- a/src/router.rs
+++ b/src/router.rs
@@ -202,7 +202,13 @@ pub struct RouteResult<'a> {
 
 impl<'a> RouteResult<'a> {
     pub fn param(&self, key: &str) -> &str {
-        let idx = self.route.variables.find_equiv(&key).unwrap();
+        let idx = match self.route.variables.find_equiv(&key) {
+            Some(idx) => idx,
+            None => {
+                fail!("Unknown param '{}' for route '{}'", key, self.route.path)
+            }
+        };
+
         self.params[*idx].as_slice()
     }
 }


### PR DESCRIPTION
*BREAKING CHANGE*

This will break code that tries to handle routes such as: '/foo/:bar.:baz'

You can now handle this with: '/foo/:bar'

When this route matches '/foo/cats.gif' then request.param("format") will be ".gif"

Fixed #90.

cc: @pzol @cburgdorf @SimonPersson 

Currently we're using `([,a-zA-Z0-9%_-]*)` to capture variables in a route. Journey (the Rails router) [uses `([^./?]+)`](https://github.com/rails/journey/blob/v1.0.4/lib/journey/path/pattern.rb#L89). 
I suggest using a blacklist, or we'll continue to see more bugs in this area, e.g. '/foo/:bar' won't match '/foo/你好' which seems a shame.