### PR TITLE
Reimport mustache into server module

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,3 @@
-extern crate mustache;
-
 use std::io::net::ip::{SocketAddr, IpAddr, Port};
 use std::sync::{Arc, RWLock};
 use std::collections::HashMap;
@@ -10,6 +8,7 @@ use http::server::Server as HttpServer;
 use middleware::MiddlewareStack;
 use request;
 use response;
+use mustache;
 
 pub struct Server {
     middleware_stack: MiddlewareStack,


### PR DESCRIPTION
Rust's module and crate system is kinda confusing for me (comming from Ruby land).
But I think I found a inconsistence.

In https://github.com/nickel-org/nickel.rs/blob/master/src/response.rs mustache is made available for this module scope via `use mustache`. I think the server module should use the same approach.

Correct me if I got something wrong.
