### PR TITLE
fix(router): Use new find_equiv signature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ git = "https://github.com/servo/rust-url.git"
 
 [dependencies.rust-mustache]
 
-git = "https://github.com/SimonPersson/rust-mustache.git"
+git = "https://github.com/timhabermaas/rust-mustache.git"
 
 [dependencies.groupable]
 

--- a/src/router/router.rs
+++ b/src/router/router.rs
@@ -30,7 +30,7 @@ pub struct RouteResult<'a> {
 
 impl<'a> RouteResult<'a> {
     pub fn param(&self, key: &str) -> &str {
-        let idx = self.route.variables.find_equiv(&key).unwrap();
+        let idx = self.route.variables.find_equiv(key).unwrap();
         self.params[*idx].as_slice()
     }
 }


### PR DESCRIPTION
Both nickel.rs and rust-mustache fail to compile with the current nightly build of rust (`0.13.0-nightly (88b6e93d3 2014-10-31 23:36:48 +0000)`) due to a change to the signature of `find_equiv` (see rust's [PR](https://github.com/rust-lang/rust/pull/18440)).

This PR fixes both issues, but I forked @SimonPersson's rust-mustache fork and added my repo to the `Cargo.toml`. Do we want to keep it this way until Erick merges all the changes into the original repository or should I issue a PR against @SimonPersson's fork instead?
