### PR TITLE
fix(enums): Add pub use/namespacing where required

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,10 @@ git = "https://github.com/nickel-org/groupable-rs"
 
 path = "nickel_macros"
 
+[dependencies.time]
+
+git = "https://github.com/rust-lang/time"
+
 [[example]]
 
 name = "example"

--- a/src/favicon_handler.rs
+++ b/src/favicon_handler.rs
@@ -8,7 +8,7 @@ use request;
 use response;
 use middleware::{Action, Halt, Continue, Middleware};
 use nickel_error::NickelError;
-use mimes::Ico;
+use mimes::MediaType;
 
 pub struct FaviconHandler {
     icon: Vec<u8>,
@@ -75,7 +75,7 @@ impl FaviconHandler {
 
     pub fn send_favicon (&self, req: &request::Request, res: &mut response::Response) {
         debug!("{} {}", req.origin.method, self.icon_path.display());
-        res.content_type(Ico);
+        res.content_type(MediaType::Ico);
         res.send(self.icon.as_slice());
     }
 }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -2,6 +2,8 @@ use request::Request;
 use response::Response;
 use nickel_error::NickelError;
 
+pub use self::Action::{Continue, Halt};
+
 pub type MiddlewareResult = Result<Action, NickelError>;
 
 #[deriving(PartialEq)]

--- a/src/mimes.rs
+++ b/src/mimes.rs
@@ -1,5 +1,5 @@
 use http::headers::content_type;
-use std::from_str::FromStr;
+use std::str::FromStr;
 
 macro_rules! mimes(
     ($($t:expr { $($name:ident, $as_s:pat, $subt:expr,)+ })+) => (
@@ -17,7 +17,7 @@ macro_rules! mimes(
             let (ty, subty) = match ty {
                 $(
                     $(
-                        $name => ($t, $subt)
+                        MediaType::$name => ($t, $subt)
                     ),*
                 ),*
             };
@@ -34,7 +34,7 @@ macro_rules! mimes(
                 match s {
                     $(
                         $(
-                            $as_s => Some($name)
+                            $as_s => Some(MediaType::$name)
                         ),*
                     ),*,
                     _ => None

--- a/src/nickel_error.rs
+++ b/src/nickel_error.rs
@@ -1,6 +1,8 @@
 use std::str::SendStr;
 use http::status::Status;
 
+pub use self::NickelErrorKind::{ErrorWithStatusCode, UserDefinedError, Other};
+
 /// NickelError is the basic error type for HTTP errors as well as user defined errors.
 /// One can pattern match against the `kind` property to handle the different cases.
 

--- a/src/router/request_handler.rs
+++ b/src/router/request_handler.rs
@@ -5,7 +5,7 @@ use http::headers;
 use std::fmt::Show;
 use middleware::{MiddlewareResult, Halt};
 use serialize::json;
-use mimes::{MediaType, Html, Json};
+use mimes::MediaType;
 
 /// Handles a HTTP request
 /// This is pre-implemented for any function which takes a
@@ -36,21 +36,21 @@ pub trait ResponseFinalizer {
 
 impl ResponseFinalizer for () {
     fn respond(self, res: &mut Response) -> MiddlewareResult {
-        maybe_set_type(res, Html);
+        maybe_set_type(res, MediaType::Html);
         Ok(Halt)
     }
 }
 
 impl ResponseFinalizer for MiddlewareResult {
     fn respond(self, res: &mut Response) -> MiddlewareResult {
-        maybe_set_type(res, Html);
+        maybe_set_type(res, MediaType::Html);
         self
     }
 }
 
 impl ResponseFinalizer for json::Json {
     fn respond(self, res: &mut Response) -> MiddlewareResult {
-        maybe_set_type(res, Json);
+        maybe_set_type(res, MediaType::Json);
         res.send(json::encode(&self));
         Ok(Halt)
     }
@@ -58,7 +58,7 @@ impl ResponseFinalizer for json::Json {
 
 impl<'a, S: Show> ResponseFinalizer for &'a [S] {
     fn respond(self, res: &mut Response) -> MiddlewareResult {
-        maybe_set_type(res, Html);
+        maybe_set_type(res, MediaType::Html);
         res.origin.status = status::Ok;
         for ref s in self.iter() {
             // FIXME : failure unhandled
@@ -83,7 +83,7 @@ macro_rules! dual_impl(
 dual_impl!(&'a str,
            String
             |self, res| {
-                maybe_set_type(res, Html);
+                maybe_set_type(res, MediaType::Html);
                 res.origin.status = status::Ok;
                 res.send(self);
                 Ok(Halt)
@@ -92,7 +92,7 @@ dual_impl!(&'a str,
 dual_impl!((status::Status, &'a str),
            (status::Status, String)
             |self, res| {
-                maybe_set_type(res, Html);
+                maybe_set_type(res, MediaType::Html);
                 let (status, data) = self;
                 res.origin.status = status;
                 res.send(data);
@@ -102,7 +102,7 @@ dual_impl!((status::Status, &'a str),
 dual_impl!((uint, &'a str),
            (uint, String)
            |self, res| {
-                maybe_set_type(res, Html);
+                maybe_set_type(res, MediaType::Html);
                 let (status, data) = self;
                 match FromPrimitive::from_uint(status) {
                     Some(status) => {
@@ -124,7 +124,7 @@ dual_impl!((status::Status, &'a str, Vec<headers::response::Header>),
                 for header in headers.into_iter() {
                     res.origin.headers.insert(header);
                 }
-                maybe_set_type(res, Html);
+                maybe_set_type(res, MediaType::Html);
                 res.send(data);
                 Ok(Halt)
             })


### PR DESCRIPTION
BREAKING CHANGE: This change will require users to reference
mime types using their namespace. i.e. MediaType::Json.
Rust enums were updated in the latest nightly (rust-lang/rust#18973).

I added pub use in places where the enums wouldn't be poluting user
namespaces with a large amount of names.

I also switched to the upstreams of rust-http and rust-url. It seems that the nickel-org forks no longer diverge from their upstreams. I'm happy to split this change into a second PR.
