### PR TITLE
feat(nickel): Added a println of IP:Port when the server starts listening for requests.

### DIFF
--- a/src/nickel.rs
+++ b/src/nickel.rs
@@ -208,6 +208,13 @@ impl Nickel {
         }
 
         self.middleware_stack.add_middleware(not_found_handler);
+
+        match port {
+            80u16 =>  println!("Listening on http://{}", ip),
+            _ =>  println!("Listening on http://{}:{}", ip, port),
+        }
+        println!("Ctrl-C to shutdown server");
+
         Server::new(self.middleware_stack, ip, port).serve();
     }
 }


### PR DESCRIPTION
Hello,

Rust beginner here, and I wonder why there isn't a printout of the `ip:port` when the server starts. I find this output to be useful (as with many other server frameworks) because you don't have to refer to the source file to know what port it is.

If the absence of this printout is intentional, feel free to close this PR.

Thanks!
