### PR TITLE
fix(*): IO module was renamed.

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -10,7 +10,7 @@ use nickel::{
     QueryString, JsonBody, StaticFilesHandler, MiddlewareResult, HttpRouter
 };
 use nickel::mimes::MediaType;
-use std::io::net::ip::Ipv4Addr;
+use std::old_io::net::ip::Ipv4Addr;
 use std::collections::BTreeMap;
 use serialize::json::{Json, ToJson};
 

--- a/examples/example_route_data.rs
+++ b/examples/example_route_data.rs
@@ -7,7 +7,7 @@ extern crate http;
 use nickel::{
     Nickel, Request, Response, HttpRouter
 };
-use std::io::net::ip::Ipv4Addr;
+use std::old_io::net::ip::Ipv4Addr;
 use std::sync::atomic::AtomicUint;
 use std::sync::atomic::Ordering::Relaxed;
 

--- a/examples/example_template.rs
+++ b/examples/example_template.rs
@@ -5,7 +5,7 @@ extern crate nickel;
 extern crate http;
 
 use nickel::{Nickel, Request, Response, HttpRouter};
-use std::io::net::ip::Ipv4Addr;
+use std::old_io::net::ip::Ipv4Addr;
 use std::collections::HashMap;
 
 fn main() {

--- a/examples/example_with_default_router.rs
+++ b/examples/example_with_default_router.rs
@@ -5,7 +5,7 @@ extern crate nickel;
 extern crate http;
 
 use nickel::{Nickel, Request, Response, HttpRouter};
-use std::io::net::ip::Ipv4Addr;
+use std::old_io::net::ip::Ipv4Addr;
 
 fn main() {
     let mut server = Nickel::new();

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -5,7 +5,7 @@
 extern crate nickel;
 
 use nickel::Nickel;
-use std::io::net::ip::Ipv4Addr;
+use std::old_io::net::ip::Ipv4Addr;
 
 fn main() {
     let mut server = Nickel::new();

--- a/examples/macro_example.rs
+++ b/examples/macro_example.rs
@@ -13,7 +13,7 @@ use nickel::{
     QueryString, JsonBody, StaticFilesHandler, MiddlewareResult, HttpRouter
 };
 use nickel::mimes::MediaType;
-use std::io::net::ip::Ipv4Addr;
+use std::old_io::net::ip::Ipv4Addr;
 
 #[derive(Decodable, Encodable)]
 struct Person {

--- a/src/favicon_handler.rs
+++ b/src/favicon_handler.rs
@@ -1,4 +1,4 @@
-use std::io::File;
+use std::old_io::File;
 
 use http::server::request::RequestUri::AbsolutePath;
 use http::method::{Get, Head, Options};

--- a/src/nickel.rs
+++ b/src/nickel.rs
@@ -1,4 +1,4 @@
-use std::io::net::ip::{Port, IpAddr};
+use std::old_io::net::ip::{Port, IpAddr};
 
 use request::Request;
 use response::Response;
@@ -138,7 +138,7 @@ impl Nickel {
     /// # Example
     /// ```{rust,no_run}
     /// use nickel::Nickel;
-    /// use std::io::net::ip::IpAddr::Ipv4Addr;
+    /// use std::old_io::net::ip::IpAddr::Ipv4Addr;
     ///
     /// let mut server = Nickel::new();
     /// server.listen(Ipv4Addr(127, 0, 0, 1), 6767);

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,8 +1,8 @@
 use std::sync::RwLock;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
-use std::io::{IoResult, File};
-use std::io::util::copy;
+use std::old_io::{IoResult, File};
+use std::old_io::util::copy;
 use std::path::BytesContainer;
 use serialize::Encodable;
 use http;
@@ -78,7 +78,7 @@ impl<'a, 'b> Response<'a, 'b> {
         // TODO: This needs to be more sophisticated to return the correct headers
         // not just "some headers" :)
         Response::set_headers(self.origin);
-        let _ = self.origin.write(text.container_as_bytes());
+        let _ = self.origin.write_all(text.container_as_bytes());
     }
 
     fn set_headers(response_writer: &mut http::server::ResponseWriter) {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,4 +1,4 @@
-use std::io::net::ip::{SocketAddr, IpAddr, Port};
+use std::old_io::net::ip::{SocketAddr, IpAddr, Port};
 use std::sync::{Arc, RwLock};
 use std::collections::HashMap;
 

--- a/src/static_files_handler.rs
+++ b/src/static_files_handler.rs
@@ -1,5 +1,5 @@
 use std::path::BytesContainer;
-use std::io::{IoError, IoResult, FileNotFound};
+use std::old_io::{IoError, IoResult, FileNotFound};
 
 use http::server::request::RequestUri::AbsolutePath;
 use http::method::{Get, Head};


### PR DESCRIPTION
The `io` module was renamed `old_io` and deprecated. As far as I can see, there's no new `io` module yet so we'll have to use `old_io` until the new `io` module arrives.