### PR TITLE
fix(response, static_files_handler): path is renamed to old_path.

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::old_io::{IoResult, File};
 use std::old_io::util::copy;
-use std::path::BytesContainer;
+use std::old_path::BytesContainer;
 use serialize::Encodable;
 use http;
 use http::server::ResponseWriter;

--- a/src/static_files_handler.rs
+++ b/src/static_files_handler.rs
@@ -1,4 +1,4 @@
-use std::path::BytesContainer;
+use std::old_path::BytesContainer;
 use std::old_io::{IoError, IoResult, FileNotFound};
 
 use http::server::request::RequestUri::AbsolutePath;


### PR DESCRIPTION
We should probably use the new path module instead, but as we're looking to move from rust_http to hyper anyway, this works for now.