### PR TITLE
chore(time, url): use dependencies from crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,6 @@ path = "src/lib.rs"
 
 git = "https://github.com/nickel-org/rust-http.git"
 
-[dependencies.url]
-
-git = "https://github.com/nickel-org/rust-url.git"
-
 [dependencies.rust-mustache]
 
 git = "https://github.com/nickel-org/rust-mustache.git"
@@ -31,10 +27,6 @@ git = "https://github.com/nickel-org/groupable-rs"
 
 path = "nickel_macros"
 
-[dependencies.time]
-
-git = "https://github.com/rust-lang/time"
-
 [dependencies]
 typemap = "*"
 plugin = "*"
@@ -42,6 +34,8 @@ regex = "*"
 regex_macros = "*"
 rustc-serialize = "*"
 log = "*"
+time = "*"
+url = "*"
 
 [[example]]
 


### PR DESCRIPTION
Since yesterday, rust-http is using deps from crates.io instead of git: https://github.com/nickel-org/rust-http/commit/22cb5e85ecea0cfe4f09440f8d58671c30642bde.

So builds are broken because the definitions of struct time::Tm in git and crates.io don't match. The solution is for nickel to use the crates.io deps as well. 

Signed-off-by: Raul Gutierrez S <rgs@itevenworks.net>