### PR TITLE
fix(middleware_handler): use from_usize instead of from_uint

### DIFF
--- a/src/middleware_handler.rs
+++ b/src/middleware_handler.rs
@@ -118,7 +118,7 @@ dual_impl!((usize, &'a str),
            |self, res| {
                 maybe_set_type(&mut res, MediaType::Html);
                 let (status, data) = self;
-                match FromPrimitive::from_uint(status) {
+                match FromPrimitive::from_usize(status) {
                     Some(status) => {
                         res.status_code(status);
                         let stream = try!(res.send(data));


### PR DESCRIPTION
Remove warning.

Signed-off-by: Raul Gutierrez S <rgs@itevenworks.net>