### PR TITLE
Default Content-Type & Temp fix for send_file deadlocking on non-existant files

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![crate_name = "nickel"]
 #![crate_type = "rlib"]
-#![feature(plugin, core, collections, io, net, path, path_ext, std_misc, old_path)]
+#![feature(plugin, core, io, net, path, path_ext, std_misc, old_path)]
 #![plugin(regex_macros)]
 
 //!Nickel is supposed to be a simple and lightweight foundation for web applications written in Rust. Its API is inspired by the popular express framework for JavaScript.
@@ -38,7 +38,7 @@ pub use json_body_parser::JsonBody;
 pub use query_string::QueryString;
 pub use router::{Router, Route, RouteResult, HttpRouter};
 pub use nickel_error::{ NickelError, NickelErrorKind, ErrorWithStatusCode, UserDefinedError, Other };
-pub use mimes::get_media_type;
+pub use mimes::{get_media_type, MediaType};
 pub use middleware_handler::ResponseFinalizer;
 
 pub mod router;

--- a/src/middleware_handler.rs
+++ b/src/middleware_handler.rs
@@ -19,7 +19,7 @@ use hyper::header;
 use hyper::net;
 use middleware::{Middleware, MiddlewareResult, Halt, Continue};
 use serialize::json;
-use mimes::MediaType;
+use mimes::{MediaType, get_media_type};
 use std::io::Write;
 
 impl Middleware for for<'a> fn(&mut Request, Response<'a>) -> MiddlewareResult<'a> {
@@ -150,7 +150,5 @@ dual_impl!((usize, &'a str),
 //             })
 
 fn maybe_set_type(res: &mut Response, ty: MediaType) {
-    if !res.origin.headers().has::<header::ContentType>() {
-        res.content_type(ty);
-    }
+    res.set_header_fallback(|| header::ContentType(get_media_type(ty)));
 }


### PR DESCRIPTION
cc #162, @SimonPersson, @ninjabear 

The 2nd commit is really just a temporary fix, we will need to adjust the `Response` api to deal with a different error type rather than `io::Result` otherwise things like this won't propagate to error handlers and it will be easy to drop the Response without flushing the buffer (which is causing the deadlocks). Hopefully deadlocks die off (no pun intended) once the 'new io' has support for timeouts, but for now we're going to have to develop an api that can hopefully ensure that it is impossible to lose the `Response` in a handler without a panic.