### PR TITLE
Refactor Response API and trim NickelError

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Then try `localhost:6767/user/4711` and `localhost:6767/bar`
 Here is how sample server in `example.rs` looks like:
 
 ```rust
-#![feature(core, io, net)]
+#![feature(core, net)]
 
 extern crate "rustc-serialize" as rustc_serialize;
 extern crate nickel;

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,4 +1,4 @@
-#![feature(core, net)]
+#![feature(core)]
 
 extern crate "rustc-serialize" as rustc_serialize;
 extern crate nickel;
@@ -9,7 +9,7 @@ use nickel::{
     Nickel, NickelError, Continue, Halt, Request,
     QueryString, JsonBody, StaticFilesHandler, HttpRouter, Action
 };
-use std::net::IpAddr;
+
 use std::collections::BTreeMap;
 use std::io::Write;
 use rustc_serialize::json::{Json, ToJson};
@@ -101,7 +101,7 @@ fn main() {
     //this is how to overwrite the default error handler to handle 404 cases with a custom view
     fn custom_404<'a>(err: &mut NickelError, _req: &mut Request) -> Action {
         if let Some(ref mut res) = err.stream {
-            if let NotFound = res.status() {
+            if res.status() == NotFound {
                 let _ = res.write_all(b"<h1>Call the police!</h1>");
                 return Halt(())
             }
@@ -116,5 +116,5 @@ fn main() {
 
     server.handle_error(custom_handler);
 
-    server.listen(IpAddr::new_v4(127, 0, 0, 1), 6767);
+    server.listen("127.0.0.1:6767");
 }

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,4 +1,4 @@
-#![feature(core, io, net)]
+#![feature(core, net)]
 
 extern crate "rustc-serialize" as rustc_serialize;
 extern crate nickel;

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -6,7 +6,7 @@ extern crate nickel;
 
 use nickel::status::StatusCode::{self, NotFound, BadRequest};
 use nickel::{
-    Nickel, NickelError, ErrorWithStatusCode, Continue, Halt, Request,
+    Nickel, NickelError, Continue, Halt, Request,
     QueryString, JsonBody, StaticFilesHandler, HttpRouter, Action
 };
 use std::net::IpAddr;
@@ -100,20 +100,16 @@ fn main() {
 
     //this is how to overwrite the default error handler to handle 404 cases with a custom view
     fn custom_404<'a>(err: &mut NickelError, _req: &mut Request) -> Action {
-        match err.kind {
-            ErrorWithStatusCode(NotFound) => {
-                // FIXME: Supportable?
-                // response.content_type(MediaType::Html)
-                //         .status_code(NotFound)
-                //         .send("<h1>Call the police!<h1>");
-                if let Some(ref mut res) = err.stream {
-                    let _ = res.write_all(b"<h1>Call the police!</h1>");
-                }
-                Halt(())
-            },
-            _ => Continue(())
+        if let Some(ref mut res) = err.stream {
+            if let NotFound = res.status() {
+                let _ = res.write_all(b"<h1>Call the police!</h1>");
+                return Halt(())
+            }
         }
+
+        Continue(())
     }
+
 
     // issue #20178
     let custom_handler: fn(&mut NickelError, &mut Request) -> Action = custom_404;

--- a/examples/example_route_data.rs
+++ b/examples/example_route_data.rs
@@ -2,7 +2,7 @@
 
 extern crate nickel;
 
-use nickel::{Nickel, Request, Response, HttpRouter, MiddlewareResult, Halt};
+use nickel::{Nickel, Request, Response, HttpRouter, MiddlewareResult};
 use std::net::IpAddr;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::Relaxed;
@@ -17,8 +17,7 @@ fn main() {
     fn root_handler<'a>(_: &mut Request, response: Response<'a>, logger: &Logger)
             -> MiddlewareResult<'a> {
         let text = format!("{}", logger.visits.fetch_add(1, Relaxed));
-        let response = try!(response.send(text));
-        Ok(Halt(response))
+        response.send(text)
     }
 
     // issue #20178

--- a/examples/example_route_data.rs
+++ b/examples/example_route_data.rs
@@ -1,9 +1,6 @@
-#![feature(net)]
-
 extern crate nickel;
 
 use nickel::{Nickel, Request, Response, HttpRouter, MiddlewareResult};
-use std::net::IpAddr;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::Relaxed;
 
@@ -24,5 +21,5 @@ fn main() {
     let rhandler: for <'a> fn(&mut Request, Response<'a>, &Logger) -> MiddlewareResult<'a> = root_handler;
 
     server.get("/", (rhandler, Logger{visits: AtomicUsize::new(0)}));
-    server.listen(IpAddr::new_v4(127, 0, 0, 1), 6767);
+    server.listen("127.0.0.1:6767");
 }

--- a/examples/example_template.rs
+++ b/examples/example_template.rs
@@ -1,9 +1,7 @@
-#![feature(net)]
 extern crate nickel;
 #[macro_use] extern crate nickel_macros;
 
 use nickel::{Nickel, Request, Response, HttpRouter, MiddlewareResult};
-use std::net::IpAddr;
 use std::collections::HashMap;
 
 fn main() {
@@ -17,5 +15,5 @@ fn main() {
 
     server.get("/", middleware!(@handler));
 
-    server.listen(IpAddr::new_v4(127, 0, 0, 1), 6767);
+    server.listen("127.0.0.1:6767");
 }

--- a/examples/example_template.rs
+++ b/examples/example_template.rs
@@ -2,7 +2,7 @@
 extern crate nickel;
 #[macro_use] extern crate nickel_macros;
 
-use nickel::{Nickel, Request, Response, HttpRouter, MiddlewareResult, Halt};
+use nickel::{Nickel, Request, Response, HttpRouter, MiddlewareResult};
 use std::net::IpAddr;
 use std::collections::HashMap;
 
@@ -12,7 +12,7 @@ fn main() {
     fn handler<'a>(_: &mut Request, res: Response<'a>) -> MiddlewareResult<'a> {
         let mut data = HashMap::<&str, &str>::new();
         data.insert("name", "user");
-        Ok(Halt(try!(res.render("examples/assets/template.tpl", &data))))
+        res.render("examples/assets/template.tpl", &data)
     }
 
     server.get("/", middleware!(@handler));

--- a/examples/example_with_default_router.rs
+++ b/examples/example_with_default_router.rs
@@ -1,9 +1,7 @@
-#![feature(net)]
 extern crate nickel;
 #[macro_use] extern crate nickel_macros;
 
 use nickel::{Nickel, HttpRouter};
-use std::net::IpAddr;
 
 fn main() {
     let mut server = Nickel::new();
@@ -16,5 +14,5 @@ fn main() {
         format!("Foo is '{}'", request.param("foo"))
     });
 
-    server.listen(IpAddr::new_v4(127, 0, 0, 1), 6767);
+    server.listen("127.0.0.1:6767");
 }

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,9 +1,7 @@
-#![feature(plugin, net)]
 #[macro_use] extern crate nickel_macros;
 extern crate nickel;
 
 use nickel::Nickel;
-use std::net::IpAddr;
 
 fn main() {
     let mut server = Nickel::new();
@@ -14,5 +12,5 @@ fn main() {
         }
     });
 
-    server.listen(IpAddr::new_v4(127, 0, 0, 1), 6767);
+    server.listen("127.0.0.1:6767");
 }

--- a/examples/macro_example.rs
+++ b/examples/macro_example.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, core, net)]
+#![feature(core)]
 
 extern crate url;
 extern crate nickel;
@@ -11,7 +11,6 @@ use nickel::{
     QueryString, JsonBody, StaticFilesHandler, MiddlewareResult, HttpRouter, Action
 };
 use std::io::Write;
-use std::net::IpAddr;
 
 #[derive(RustcDecodable, RustcEncodable)]
 struct Person {
@@ -28,7 +27,7 @@ fn logger<'a>(request: &mut Request, response: Response<'a>) -> MiddlewareResult
 //this is how to overwrite the default error handler to handle 404 cases with a custom view
 fn custom_404<'a>(err: &mut NickelError, _req: &mut Request) -> Action {
     if let Some(ref mut res) = err.stream {
-        if let NotFound = res.status() {
+        if res.status() == NotFound {
             let _ = res.write_all(b"<h1>Call the police!</h1>");
             return Halt(())
         }
@@ -113,5 +112,5 @@ fn main() {
     server.handle_error(custom_handler);
 
     println!("Running server!");
-    server.listen(IpAddr::new_v4(127, 0, 0, 1), 6767);
+    server.listen("127.0.0.1:6767");
 }

--- a/examples/macro_example.rs
+++ b/examples/macro_example.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, core, io, net)]
+#![feature(plugin, core, net)]
 
 extern crate url;
 extern crate nickel;

--- a/src/as_bytes.rs
+++ b/src/as_bytes.rs
@@ -1,0 +1,19 @@
+pub trait AsBytes {
+    fn as_bytes(&self) -> &[u8];
+}
+
+impl<'a> AsBytes for &'a str {
+    fn as_bytes(&self) -> &[u8] { <str as StrExt>::as_bytes(*self) }
+}
+
+impl<'a> AsBytes for &'a [u8] {
+    fn as_bytes(&self) -> &[u8] { self }
+}
+
+impl AsBytes for String {
+    fn as_bytes(&self) -> &[u8] { self[..].as_bytes() }
+}
+
+impl AsBytes for Vec<u8> {
+    fn as_bytes(&self) -> &[u8] { &self[..] }
+}

--- a/src/as_bytes.rs
+++ b/src/as_bytes.rs
@@ -3,7 +3,7 @@ pub trait AsBytes {
 }
 
 impl<'a> AsBytes for &'a str {
-    fn as_bytes(&self) -> &[u8] { <str as StrExt>::as_bytes(*self) }
+    fn as_bytes(&self) -> &[u8] { str::as_bytes(*self) }
 }
 
 impl<'a> AsBytes for &'a [u8] {

--- a/src/default_error_handler.rs
+++ b/src/default_error_handler.rs
@@ -1,7 +1,7 @@
 use hyper::status::StatusCode::{NotFound, BadRequest};
 use request::Request;
 use middleware::{ErrorHandler, Action, Halt};
-use nickel_error::{NickelError, ErrorWithStatusCode};
+use nickel_error::NickelError;
 use std::io::Write;
 
 #[derive(Clone, Copy)]
@@ -10,9 +10,9 @@ pub struct DefaultErrorHandler;
 impl ErrorHandler for DefaultErrorHandler {
     fn handle_error(&self, err: &mut NickelError, _req: &mut Request) -> Action {
         if let Some(ref mut res) = err.stream {
-            let msg = match err.kind {
-                ErrorWithStatusCode(NotFound) => b"Not Found",
-                ErrorWithStatusCode(BadRequest) => b"Bad Request",
+            let msg = match res.status() {
+                NotFound => b"Not Found",
+                BadRequest => b"Bad Request",
                 _ => b"Internal Server Error"
             };
 

--- a/src/default_error_handler.rs
+++ b/src/default_error_handler.rs
@@ -10,7 +10,7 @@ pub struct DefaultErrorHandler;
 impl ErrorHandler for DefaultErrorHandler {
     fn handle_error(&self, err: &mut NickelError, _req: &mut Request) -> Action {
         if let Some(ref mut res) = err.stream {
-            let msg = match res.status() {
+            let msg : &[u8] = match res.status() {
                 NotFound => b"Not Found",
                 BadRequest => b"Bad Request",
                 _ => b"Internal Server Error"

--- a/src/default_error_handler.rs
+++ b/src/default_error_handler.rs
@@ -17,6 +17,8 @@ impl ErrorHandler for DefaultErrorHandler {
             };
 
             let _ = res.write_all(msg);
+        } else {
+            println!("Error: {}", err.message);
         }
 
         Halt(())

--- a/src/favicon_handler.rs
+++ b/src/favicon_handler.rs
@@ -66,12 +66,12 @@ impl FaviconHandler {
                 self.send_favicon(req, res)
             },
             Options => {
-                res.status_code(StatusCode::Ok);
+                res.set_status(StatusCode::Ok);
                 res.origin.headers_mut().set(header::Allow(vec!(Get, Head, Options)));
                 res.send("")
             },
             _ => {
-                res.status_code(StatusCode::MethodNotAllowed);
+                res.set_status(StatusCode::MethodNotAllowed);
                 res.origin.headers_mut().set(header::Allow(vec!(Get, Head, Options)));
                 res.send("")
             }

--- a/src/favicon_handler.rs
+++ b/src/favicon_handler.rs
@@ -19,7 +19,7 @@ pub struct FaviconHandler {
 }
 
 impl Middleware for FaviconHandler {
-    fn invoke<'a, 'b>(&'a self, req: &mut Request<'b, 'a>, res: Response<'a, net::Fresh>)
+    fn invoke<'a, 'b>(&'a self, req: &mut Request<'b, 'a, 'b>, res: Response<'a, net::Fresh>)
             -> MiddlewareResult<'a> {
         if FaviconHandler::is_favicon_request(req) {
             self.handle_request(req, res)

--- a/src/favicon_handler.rs
+++ b/src/favicon_handler.rs
@@ -10,7 +10,7 @@ use hyper::net;
 
 use request::Request;
 use response::Response;
-use middleware::{Halt, Continue, Middleware, MiddlewareResult};
+use middleware::{Continue, Middleware, MiddlewareResult};
 use mimes::MediaType;
 
 pub struct FaviconHandler {
@@ -68,14 +68,12 @@ impl FaviconHandler {
             Options => {
                 res.status_code(StatusCode::Ok);
                 res.origin.headers_mut().set(header::Allow(vec!(Get, Head, Options)));
-                let stream = try!(res.send(""));
-                Ok(Halt(stream))
+                res.send("")
             },
             _ => {
                 res.status_code(StatusCode::MethodNotAllowed);
                 res.origin.headers_mut().set(header::Allow(vec!(Get, Head, Options)));
-                let stream = try!(res.send(""));
-                Ok(Halt(stream))
+                res.send("")
             }
         }
     }
@@ -83,7 +81,6 @@ impl FaviconHandler {
     pub fn send_favicon<'a, 'b>(&self, req: &Request, mut res: Response<'a>) -> MiddlewareResult<'a> {
         debug!("{:?} {:?}", req.origin.method, self.icon_path.display());
         res.content_type(MediaType::Ico);
-        let stream = try!(res.send(&*self.icon));
-        Ok(Halt(stream))
+        res.send(&*self.icon)
     }
 }

--- a/src/json_body_parser.rs
+++ b/src/json_body_parser.rs
@@ -8,7 +8,7 @@ use std::io::{Read, ErrorKind};
 // Plugin boilerplate
 struct JsonBodyParser;
 impl Key for JsonBodyParser { type Value = String; }
-impl<'a, 'b> Plugin<Request<'a, 'b>> for JsonBodyParser {
+impl<'a, 'b, 'k> Plugin<Request<'a, 'b, 'k>> for JsonBodyParser {
     type Error = io::Error;
 
     fn eval(req: &mut Request) -> io::Result<String> {
@@ -22,7 +22,7 @@ pub trait JsonBody {
     fn json_as<T: Decodable>(&mut self) -> io::Result<T>;
 }
 
-impl<'a, 'b> JsonBody for Request<'a, 'b> {
+impl<'a, 'b, 'k> JsonBody for Request<'a, 'b, 'k> {
     fn json_as<T: Decodable>(&mut self) -> io::Result<T> {
         self.get::<JsonBodyParser>().and_then(|parsed|
             json::decode::<T>(&*parsed).map_err(|err|

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub use default_error_handler::DefaultErrorHandler;
 pub use json_body_parser::JsonBody;
 pub use query_string::QueryString;
 pub use router::{Router, Route, RouteResult, HttpRouter};
-pub use nickel_error::{ NickelError, NickelErrorKind, ErrorWithStatusCode, UserDefinedError, Other };
+pub use nickel_error::NickelError;
 pub use mimes::{get_media_type, MediaType};
 pub use middleware_handler::ResponseFinalizer;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![crate_name = "nickel"]
 #![crate_type = "rlib"]
-#![feature(plugin, core, io, net, path, path_ext, std_misc, old_path)]
+#![feature(plugin, core, io, net, path_ext, std_misc)]
 #![plugin(regex_macros)]
 
 //!Nickel is supposed to be a simple and lightweight foundation for web applications written in Rust. Its API is inspired by the popular express framework for JavaScript.
@@ -40,7 +40,9 @@ pub use router::{Router, Route, RouteResult, HttpRouter};
 pub use nickel_error::NickelError;
 pub use mimes::{get_media_type, MediaType};
 pub use middleware_handler::ResponseFinalizer;
+pub use as_bytes::AsBytes;
 
+mod as_bytes;
 pub mod router;
 mod server;
 mod nickel;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![crate_name = "nickel"]
 #![crate_type = "rlib"]
-#![feature(plugin, core, collections, io, net, path, path_ext, std_misc, old_path)]
+#![feature(plugin, core, io, net, path, path_ext, std_misc, old_path)]
 #![plugin(regex_macros)]
 
 //!Nickel is supposed to be a simple and lightweight foundation for web applications written in Rust. Its API is inspired by the popular express framework for JavaScript.
@@ -38,7 +38,7 @@ pub use json_body_parser::JsonBody;
 pub use query_string::QueryString;
 pub use router::{Router, Route, RouteResult, HttpRouter};
 pub use nickel_error::{ NickelError, NickelErrorKind, ErrorWithStatusCode, UserDefinedError, Other };
-pub use mimes::get_media_type;
+pub use mimes::{get_media_type, MediaType};
 pub use middleware_handler::ResponseFinalizer;
 
 pub mod router;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![crate_name = "nickel"]
 #![crate_type = "rlib"]
-#![feature(plugin, core, io, net, path_ext, std_misc)]
+#![feature(plugin, core, io, path_ext, std_misc)]
 #![plugin(regex_macros)]
 
 //!Nickel is supposed to be a simple and lightweight foundation for web applications written in Rust. Its API is inspired by the popular express framework for JavaScript.

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -60,11 +60,10 @@ impl MiddlewareStack {
                 }
                 Ok(Continue(fresh)) => res = fresh,
                 Err(mut err) => {
-                    warn!("{:?} {:?} {:?} {:?} {:?} {:?}",
+                    warn!("{:?} {:?} {:?} {:?} {:?}",
                           req.origin.method,
                           req.origin.remote_addr,
                           req.origin.uri,
-                          err.kind,
                           err.message,
                           err.stream.as_ref().map(|s| s.origin.status()));
 
@@ -75,11 +74,10 @@ impl MiddlewareStack {
                         }
                     }
 
-                    warn!("Unhandled error: {:?} {:?} {:?} {:?} {:?} {:?}",
+                    warn!("Unhandled error: {:?} {:?} {:?} {:?} {:?}",
                           req.origin.method,
                           req.origin.remote_addr,
                           req.origin.uri,
-                          err.kind,
                           err.message,
                           err.stream.map(|s| s.origin.status()));
                     return

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -17,7 +17,7 @@ pub enum Action<T=(), U=()> {
 // the usage of + Send is weird here because what we really want is + Static
 // but that's not possible as of today. We have to use + Send for now.
 pub trait Middleware: Send + 'static + Sync {
-    fn invoke<'a, 'b>(&'a self, _req: &mut Request<'b, 'a>, res: Response<'a, net::Fresh>) -> MiddlewareResult<'a> {
+    fn invoke<'a, 'b>(&'a self, _req: &mut Request<'b, 'a, 'b>, res: Response<'a, net::Fresh>) -> MiddlewareResult<'a> {
         Ok(Continue(res))
     }
 }
@@ -46,7 +46,7 @@ impl MiddlewareStack {
         self.error_handlers.push(Box::new(handler));
     }
 
-    pub fn invoke<'a>(&'a self, mut req: Request<'a, 'a>, mut res: Response<'a>) {
+    pub fn invoke<'a, 'b>(&'a self, mut req: Request<'a, 'a, 'b>, mut res: Response<'a>) {
         for handler in self.handlers.iter() {
             match handler.invoke(&mut req, res) {
                 Ok(Halt(res)) => {

--- a/src/middleware_handler.rs
+++ b/src/middleware_handler.rs
@@ -19,7 +19,7 @@ use hyper::header;
 use hyper::net;
 use middleware::{Middleware, MiddlewareResult, Halt, Continue};
 use serialize::json;
-use mimes::MediaType;
+use mimes::{MediaType, get_media_type};
 use std::io::Write;
 
 impl Middleware for for<'a> fn(&mut Request, Response<'a>) -> MiddlewareResult<'a> {
@@ -150,7 +150,5 @@ dual_impl!((usize, &'a str),
 //             })
 
 fn maybe_set_type(res: &mut Response, ty: MediaType) {
-    if !res.origin.headers().has::<header::ContentType>() {
-        res.content_type(ty);
-    }
+    res.set_header_fallback(|| header::ContentType(get_media_type(ty)));
 }

--- a/src/middleware_handler.rs
+++ b/src/middleware_handler.rs
@@ -23,14 +23,14 @@ use mimes::{MediaType, get_media_type};
 use std::io::Write;
 
 impl Middleware for for<'a> fn(&mut Request, Response<'a>) -> MiddlewareResult<'a> {
-    fn invoke<'a, 'b>(&'a self, req: &mut Request<'b, 'a>, res: Response<'a>) -> MiddlewareResult<'a> {
+    fn invoke<'a, 'b>(&'a self, req: &mut Request<'b, 'a, 'b>, res: Response<'a>) -> MiddlewareResult<'a> {
         (*self)(req, res)
     }
 }
 
 impl<T> Middleware for (for <'a> fn(&mut Request, Response<'a>, &T) -> MiddlewareResult<'a>, T)
         where T: Send + Sync + 'static {
-    fn invoke<'a, 'b>(&'a self, req: &mut Request<'b, 'a>, res: Response<'a>) -> MiddlewareResult<'a> {
+    fn invoke<'a, 'b>(&'a self, req: &mut Request<'b, 'a, 'b>, res: Response<'a>) -> MiddlewareResult<'a> {
         let (f, ref data) = *self;
         f(req, res, data)
     }

--- a/src/middleware_handler.rs
+++ b/src/middleware_handler.rs
@@ -69,7 +69,7 @@ impl ResponseFinalizer for json::Json {
 impl<'a, S: Display> ResponseFinalizer for &'a [S] {
     fn respond<'c>(self, mut res: Response<'c>) -> MiddlewareResult<'c> {
         maybe_set_type(&mut res, MediaType::Html);
-        res.status_code(StatusCode::Ok);
+        res.set_status(StatusCode::Ok);
         let mut stream = try!(res.start());
         for ref s in self.iter() {
             // FIXME : This error handling is poor
@@ -99,7 +99,7 @@ dual_impl!(&'a str,
             |self, res| {
                 maybe_set_type(&mut res, MediaType::Html);
 
-                res.status_code(StatusCode::Ok);
+                res.set_status(StatusCode::Ok);
                 res.send(self)
             });
 
@@ -109,7 +109,7 @@ dual_impl!((StatusCode, &'a str),
                 maybe_set_type(&mut res, MediaType::Html);
                 let (status, data) = self;
 
-                res.status_code(status);
+                res.set_status(status);
                 res.send(data)
             });
 
@@ -120,7 +120,7 @@ dual_impl!((usize, &'a str),
                 let (status, data) = self;
                 match FromPrimitive::from_usize(status) {
                     Some(status) => {
-                        res.status_code(status);
+                        res.set_status(status);
                         res.send(data)
                     }
                     // This is a logic error

--- a/src/nickel.rs
+++ b/src/nickel.rs
@@ -1,4 +1,5 @@
-use std::net::IpAddr;
+use std::fmt::Display;
+use std::net::ToSocketAddrs;
 use router::{Router, HttpRouter};
 use middleware::{MiddlewareStack, Middleware, ErrorHandler};
 use server::Server;
@@ -85,7 +86,7 @@ impl Nickel {
     ///
     /// fn error_handler(err: &mut NickelError, req: &mut Request) -> Action {
     ///    if let Some(ref mut res) = err.stream {
-    ///        if let NotFound = res.status() {
+    ///        if res.status() == NotFound {
     ///            let _ = res.write_all(b"<h1>Call the police!</h1>");
     ///            return Halt(())
     ///        }
@@ -134,22 +135,18 @@ impl Nickel {
     /// # Examples
     /// ```{rust,no_run}
     /// use nickel::Nickel;
-    /// use std::net::IpAddr;
     ///
     /// let mut server = Nickel::new();
-    /// server.listen(IpAddr::new_v4(127, 0, 0, 1), 6767);
+    /// server.listen("127.0.0.1:6767");
     /// ```
-    pub fn listen(mut self, ip: IpAddr, port: u16) {
+    pub fn listen<T: ToSocketAddrs + Display>(mut self, addr: T) {
         self.middleware_stack.add_middleware(middleware! {
             (StatusCode::NotFound, "File Not Found")
         });
 
-        match port {
-            80u16 =>  println!("Listening on http://{}", ip),
-            _ =>  println!("Listening on http://{}:{}", ip, port),
-        }
+        println!("Listening on http://{}", addr);
         println!("Ctrl-C to shutdown server");
 
-        Server::new(self.middleware_stack).serve(ip, port);
+        Server::new(self.middleware_stack).serve(addr);
     }
 }

--- a/src/nickel.rs
+++ b/src/nickel.rs
@@ -80,20 +80,18 @@ impl Nickel {
     /// # fn main() {
     /// use std::io::Write;
     /// use nickel::{Nickel, Request, Response, Continue, Halt};
-    /// use nickel::{NickelError, ErrorWithStatusCode, Action};
+    /// use nickel::{NickelError, Action};
     /// use nickel::status::StatusCode::NotFound;
     ///
     /// fn error_handler(err: &mut NickelError, req: &mut Request) -> Action {
-    ///    match err.kind {
-    ///        ErrorWithStatusCode(NotFound) => {
-    ///            if let Some(ref mut res) = err.stream {
-    ///                let _ = res.write_all(b"<h1>Call the police!</h1>");
-    ///            }
-    ///            Halt(())
-    ///
-    ///        },
-    ///        _ => Continue(())
+    ///    if let Some(ref mut res) = err.stream {
+    ///        if let NotFound = res.status() {
+    ///            let _ = res.write_all(b"<h1>Call the police!</h1>");
+    ///            return Halt(())
+    ///        }
     ///    }
+    ///
+    ///     Continue(())
     /// }
     ///
     /// let mut server = Nickel::new();

--- a/src/nickel_error.rs
+++ b/src/nickel_error.rs
@@ -25,9 +25,7 @@ impl<'a> NickelError<'a> {
     /// use nickel::status::StatusCode;
     ///
     /// fn handler<'a>(_: &mut Request, mut res: Response<'a>) -> MiddlewareResult<'a> {
-    ///     Err(NickelError::new(res,
-    ///                          "Error Parsing JSON",
-    ///                          StatusCode::BadRequest))
+    ///     Err(NickelError::new(res, "Error Parsing JSON", StatusCode::BadRequest))
     /// }
     /// # }
     /// ```
@@ -38,12 +36,11 @@ impl<'a> NickelError<'a> {
         stream.set_status(status_code);
 
         match stream.start() {
-            Ok(stream) => {
+            Ok(stream) =>
                 NickelError {
                     stream: Some(stream),
                     message: message.into_cow(),
-                }
-            },
+                },
             Err(e) => e
         }
     }
@@ -51,7 +48,7 @@ impl<'a> NickelError<'a> {
     /// Creates a new `NickelError` without a `Response`.
     ///
     /// This should only be called in a state where the `Response` has
-    /// has failed in an unrecoverable state. If there is an available
+    /// failed in an unrecoverable state. If there is an available
     /// `Response` then it must be provided to `new` so that the
     /// underlying stream can be flushed, allowing future requests.
     ///

--- a/src/nickel_error.rs
+++ b/src/nickel_error.rs
@@ -59,11 +59,9 @@ impl<'a> NickelError<'a> {
     /// does not have the underlying stream flushed when processing is finished.
     pub unsafe fn without_response<T>(message: T) -> NickelError<'a>
             where T: IntoCow<'static, str> {
-        let message = message.into_cow();
-        println!("Error: {}", message);
         NickelError {
             stream: None,
-            message: message,
+            message: message.into_cow(),
         }
     }
 

--- a/src/query_string.rs
+++ b/src/query_string.rs
@@ -14,7 +14,7 @@ type QueryStore = HashMap<String, Vec<String>>;
 struct QueryStringParser;
 impl Key for QueryStringParser { type Value = QueryStore; }
 
-impl<'a, 'b> Plugin<Request<'a, 'b>> for QueryStringParser {
+impl<'a, 'b, 'k> Plugin<Request<'a, 'b, 'k>> for QueryStringParser {
     type Error = ();
 
     fn eval(req: &mut Request) -> Result<QueryStore, ()> {
@@ -26,7 +26,7 @@ pub trait QueryString {
     fn query(&mut self, key: &str, default: &str) -> Cow<[String]>;
 }
 
-impl<'a, 'b> QueryString for Request<'a, 'b> {
+impl<'a, 'b, 'k> QueryString for Request<'a, 'b, 'k> {
     fn query(&mut self, key: &str, default: &str) -> Cow<[String]> {
         let store = self.get_ref::<QueryStringParser>()
                         .ok()

--- a/src/request.rs
+++ b/src/request.rs
@@ -4,17 +4,17 @@ use typemap::TypeMap;
 use hyper::server::Request as HyperRequest;
 
 ///A container for all the request data
-pub struct Request<'a, 'b: 'a> {
+pub struct Request<'a, 'b: 'k, 'k: 'a> {
     ///the original `hyper::server::Request`
-    pub origin: HyperRequest<'a>,
+    pub origin: HyperRequest<'a, 'k>,
     ///a `HashMap<String, String>` holding all params with names and values
     pub route_result: Option<RouteResult<'b>>,
 
     map: TypeMap
 }
 
-impl<'a, 'b> Request<'a, 'b> {
-    pub fn from_internal(req: HyperRequest<'a>) -> Request<'a, 'b> {
+impl<'a, 'b, 'k> Request<'a, 'b, 'k> {
+    pub fn from_internal(req: HyperRequest<'a, 'k>) -> Request<'a, 'b, 'k> {
         Request {
             origin: req,
             route_result: None,
@@ -27,7 +27,7 @@ impl<'a, 'b> Request<'a, 'b> {
     }
 }
 
-impl<'a, 'b> Extensible for Request<'a, 'b> {
+impl<'a, 'b, 'k> Extensible for Request<'a, 'b, 'k> {
     fn extensions(&self) -> &TypeMap {
         &self.map
     }
@@ -37,4 +37,4 @@ impl<'a, 'b> Extensible for Request<'a, 'b> {
     }
 }
 
-impl<'a, 'b> Pluggable for Request<'a, 'b> {}
+impl<'a, 'b, 'k> Pluggable for Request<'a, 'b, 'k> {}

--- a/src/response.rs
+++ b/src/response.rs
@@ -2,7 +2,6 @@ use std::borrow::IntoCow;
 use std::sync::RwLock;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
-use std::old_path::BytesContainer;
 use std::path::Path;
 use serialize::Encodable;
 use hyper::status::StatusCode::{self, InternalServerError};
@@ -16,7 +15,7 @@ use mustache::Template;
 use std::io;
 use std::io::{Read, Write, copy};
 use std::fs::File;
-use {NickelError, Halt, MiddlewareResult};
+use {NickelError, Halt, MiddlewareResult, AsBytes};
 
 pub type TemplateCache = RwLock<HashMap<&'static str, Template>>;
 
@@ -82,9 +81,9 @@ impl<'a> Response<'a, Fresh> {
     ///     res.send("hello world")
     /// }
     /// ```
-    pub fn send<T: BytesContainer> (self, text: T) -> MiddlewareResult<'a> {
+    pub fn send<T: AsBytes>(self, text: T) -> MiddlewareResult<'a> {
         let mut stream = try!(self.start());
-        match stream.write_all(text.container_as_bytes()) {
+        match stream.write_all(&text.as_bytes()) {
             Ok(()) => Ok(Halt(stream)),
             Err(e) => stream.bail(format!("Failed to send: {}", e))
         }

--- a/src/response.rs
+++ b/src/response.rs
@@ -63,11 +63,11 @@ impl<'a> Response<'a, Fresh> {
     /// use nickel::status::StatusCode;
     ///
     /// fn handler<'a>(_: &mut Request, mut res: Response<'a>) -> MiddlewareResult<'a> {
-    ///     res.status_code(StatusCode::NotFound);
+    ///     res.set_status(StatusCode::NotFound);
     ///     Ok(Continue(res))
     /// }
     /// ```
-    pub fn status_code(&mut self, status: StatusCode) -> &mut Response<'a> {
+    pub fn set_status(&mut self, status: StatusCode) -> &mut Response<'a> {
         *self.origin.status_mut() = status;
         self
     }
@@ -263,6 +263,13 @@ impl<'a, 'b> Response<'a, Streaming> {
     /// Flushes all writing of a response to the client.
     pub fn end(self) -> io::Result<()> {
         self.origin.end()
+    }
+}
+
+impl <'a, T> Response<'a, T> {
+    /// Gets the current status code for this response
+    pub fn status(&self) -> StatusCode {
+        self.origin.status()
     }
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -83,7 +83,7 @@ impl<'a> Response<'a, Fresh> {
     /// ```
     pub fn send<T: AsBytes>(self, text: T) -> MiddlewareResult<'a> {
         let mut stream = try!(self.start());
-        match stream.write_all(&text.as_bytes()) {
+        match stream.write_all(text.as_bytes()) {
             Ok(()) => Ok(Halt(stream)),
             Err(e) => stream.bail(format!("Failed to send: {}", e))
         }
@@ -228,11 +228,10 @@ impl<'a> Response<'a, Fresh> {
         let Response { origin, templates } = self;
         match origin.start() {
             Ok(origin) => Ok(Response { origin: origin, templates: templates }),
-            Err(e) => {
+            Err(e) =>
                 unsafe {
                     Err(NickelError::without_response(format!("Failed to start response: {}", e)))
                 }
-            }
         }
     }
 }

--- a/src/router/router.rs
+++ b/src/router/router.rs
@@ -109,7 +109,7 @@ impl Middleware for Router {
 
         match route_result {
             Some(route_result) => {
-                res.status_code(StatusCode::Ok);
+                res.set_status(StatusCode::Ok);
                 let handler = &route_result.route.handler;
                 req.route_result = Some(route_result);
                 handler.invoke(req, res)

--- a/src/router/router.rs
+++ b/src/router/router.rs
@@ -98,7 +98,7 @@ impl HttpRouter for Router {
 }
 
 impl Middleware for Router {
-    fn invoke<'a, 'b>(&'a self, req: &mut Request<'b, 'a>, mut res: Response<'a>)
+    fn invoke<'a, 'b>(&'a self, req: &mut Request<'b, 'a, 'b>, mut res: Response<'a>)
                         -> MiddlewareResult<'a> {
         debug!("Router::invoke for '{:?}'", req.origin.uri);
         let route_result = match req.origin.uri {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,4 +1,4 @@
-use std::net::IpAddr;
+use std::net::ToSocketAddrs;
 use std::sync::{Arc, RwLock};
 use std::collections::HashMap;
 use hyper::server::{Request, Response, Handler};
@@ -14,7 +14,7 @@ pub struct Server {
 }
 
 impl Handler for Arc<Server> {
-    fn handle<'a>(&'a self, req: Request<'a>, res: Response<'a>) {
+    fn handle<'a, 'k>(&'a self, req: Request<'a, 'k>, res: Response<'a>) {
         let nickel_req = request::Request::from_internal(req);
         let nickel_res = response::Response::from_internal(res, &self.templates);
 
@@ -30,10 +30,10 @@ impl Server {
         }
     }
 
-    pub fn serve(self, ip: IpAddr, port: u16) {
+    pub fn serve<T: ToSocketAddrs>(self, addr: T) {
         let arc = Arc::new(self);
         let server = HyperServer::http(arc);
-        let _ = server.listen(ip, port);
+        let _ = server.listen(addr);
     }
 }
 

--- a/src/static_files_handler.rs
+++ b/src/static_files_handler.rs
@@ -6,7 +6,7 @@ use hyper::method::Method::{Get, Head};
 
 use request::Request;
 use response::Response;
-use middleware::{Halt, Continue, Middleware, MiddlewareResult};
+use middleware::{Continue, Middleware, MiddlewareResult};
 
 // this should be much simpler after unboxed closures land in Rust.
 
@@ -64,7 +64,7 @@ impl StaticFilesHandler {
         if let Some(path) = relative_path {
             let path = self.root_path.join(path.as_path());
             if path.exists() && path.is_file() {
-                return Ok(Halt(try!(res.send_file(&path))));
+                return res.send_file(&path);
             }
         };
 


### PR DESCRIPTION
Alternative to #168. 

Providing a separate PR incase the design isn't agreeable (this is based on that branch). 

These changes make it easier to enforce standard behavior. HTTP doesn't really allow changing the status code once a response is already in progress, so users should either bail (and log) or start an error with an appropriate code which error handlers can process. 

I considered changing the API for an ErrorHandler to take `&mut Option<Response<Streaming>>` but decided to keep `NickelError` as in the absense of a `Response` we can at least still know what the developers error message was (in case they want to log *something* to a database rather than *nothing*).