### PR TITLE
fix(query): allow multiple query params alive at once

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -85,13 +85,13 @@ fn main() {
     // try calling http://localhost:6767/query?foo=bar
     router.get("/query", middleware! { |request|
         format!("Your foo values in the query string are: {:?}",
-                request.query("foo", "This is only a default value!"))
+                request.query().get_or("foo", "This is only a default value!"))
     });
 
     // try calling http://localhost:6767/strict?state=valid
     // then try calling http://localhost:6767/strict?state=invalid
     router.get("/strict", middleware! { |request|
-        if &*request.query("state", "invalid")[0] != "valid" {
+        if &*request.query().get_or("state", "invalid")[0] != "valid" {
             (BadRequest, "Error Parsing JSON")
         } else {
             (StatusCode::Ok, "Congratulations on conforming!")

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -84,14 +84,17 @@ fn main() {
 
     // try calling http://localhost:6767/query?foo=bar
     router.get("/query", middleware! { |request|
-        format!("Your foo values in the query string are: {:?}",
-                request.query().get_or("foo", "This is only a default value!"))
+        if let Some(vals) = request.query().all("foo") {
+            format!("Your foo values in the query string are: {:?}", vals)
+        } else {
+            format!("You didn't provide any foo values!")
+        }
     });
 
     // try calling http://localhost:6767/strict?state=valid
     // then try calling http://localhost:6767/strict?state=invalid
     router.get("/strict", middleware! { |request|
-        if &*request.query().get_or("state", "invalid")[0] != "valid" {
+        if request.query().get("state") != Some("valid") {
             (BadRequest, "Error Parsing JSON")
         } else {
             (StatusCode::Ok, "Congratulations on conforming!")

--- a/examples/macro_example.rs
+++ b/examples/macro_example.rs
@@ -106,8 +106,12 @@ fn main() {
 
         // try calling http://localhost:6767/query?foo=bar
         get "/query" => |request, response| {
-            let text = format!("Your foo values in the query string are: {:?}",
-                               request.query("foo", "This is only a default value!"));
+            let query = request.query();
+            let foo = query.get_or("foo", "This is only a default value");
+            let bar = query.get_or("bar", "This is only a default value");
+            let text = format!("<p>Your foo values in the query string are: {:?}\
+                                <p>Your bar values are: {:?}",
+                               foo, bar);
             text
         }
     ));

--- a/examples/macro_example.rs
+++ b/examples/macro_example.rs
@@ -107,8 +107,8 @@ fn main() {
         // try calling http://localhost:6767/query?foo=bar
         get "/query" => |request, response| {
             let query = request.query();
-            let foo = query.get_or("foo", "This is only a default value");
-            let bar = query.get_or("bar", "This is only a default value");
+            let foo = query.get("foo").unwrap_or("This is only a default value");
+            let bar = query.get("bar").unwrap_or("This is only a default value");
             let text = format!("<p>Your foo values in the query string are: {:?}\
                                 <p>Your bar values are: {:?}",
                                foo, bar);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub use static_files_handler::StaticFilesHandler;
 pub use favicon_handler::FaviconHandler;
 pub use default_error_handler::DefaultErrorHandler;
 pub use json_body_parser::JsonBody;
-pub use query_string::QueryString;
+pub use query_string::{QueryString, Query};
 pub use router::{Router, Route, RouteResult, HttpRouter};
 pub use nickel_error::NickelError;
 pub use mimes::{get_media_type, MediaType};

--- a/src/router/router.rs
+++ b/src/router/router.rs
@@ -244,6 +244,24 @@ fn can_match_var_routes () {
 }
 
 #[test]
+fn params_lifetime() {
+    let route_store = &mut Router::new();
+    let handler = middleware! { "hello from foo" };
+
+    route_store.add_route(Method::Get, "/file/:format/:file", handler);
+
+    let route_result = route_store.match_route(&Method::Get, "/file/txt/manual");
+    assert!(route_result.is_some());
+
+    // Ensure two params can live without borrowck problems
+    let route_result = route_result.unwrap();
+    let format = route_result.param("format");
+    let file = route_result.param("file");
+    assert_eq!(format, "txt");
+    assert_eq!(file, "manual");
+}
+
+#[test]
 fn regex_path() {
     use regex::Regex;
 


### PR DESCRIPTION
I'd like to bikeshed on this API a bit.

Due to requiring a mutable reference to update the cached value, we can't return a view from `query`. This changes it to return a `store` which then you can then query into as much as you want without borrowck problems. An alternative is to keep the current api and then have a second method which returns the store like this currently does and maintaining the old api for the simple/average case.

I'm actually more in favor of changing the API a bit further, as I think most users will be wanting the first value in the set of matches so we should make that nicer.

```rust
let q : Query = req.query();
let bar : Option<&str> = q["bar"];
let bar : &str = bar.unwrap_or("default");

// When it only needs to live for the call
let bar : Option<&str> = req.query()["bar"];

// Alternatively this could return an empty slice instead of `None`?
let all_bar : Option<&[String]> = q.all("bar");
let all_bar : Vec<String> = all_bar.map(|v| v.to_vec()).unwrap_or(vec![]);
```

I think this would be more practical for most uses while not being too horrible for the extended case.