### PR TITLE
feat(unboxed_closures): allow unboxed closures for handlers and error handlers

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -12,6 +12,31 @@ macro_rules! router {
     )
 }
 
+/// Macro to reduce the boilerplate required for using unboxed
+/// closures as `Middleware` due to current type inference behaviour.
+///
+/// In future, the macro should hopefully be able to be removed while
+/// having minimal changes to the closure's code.
+///
+/// # Examples
+/// ```rust,no_run
+/// # #[macro_use] extern crate nickel;
+/// # fn main() {
+/// use nickel::{Nickel, HttpRouter};
+/// use std::sync::atomic::{AtomicUsize, Ordering};
+///
+/// let mut server = Nickel::new();
+///
+/// // Some shared resource between requests, must be `Sync + Send`
+/// let visits = AtomicUsize::new(0);
+///
+/// server.get("/", middleware! { |_req, _res|
+///     format!("{}", visits.fetch_add(1, Ordering::Relaxed))
+/// });
+///
+/// server.listen("127.0.0.1:6767");
+/// # }
+/// ```
 #[macro_export]
 macro_rules! middleware {
     (@$f:ident) => {{
@@ -48,4 +73,6 @@ macro_rules! middleware {
     ($($b:tt)+) => { middleware!(|req, res| $($b)+) };
 }
 
-#[macro_export] macro_rules! as_block { ($b:block) => ( $b ) }
+#[doc(hidden)]
+#[macro_export]
+macro_rules! as_block { ($b:block) => ( $b ) }

--- a/src/middleware_handler.rs
+++ b/src/middleware_handler.rs
@@ -22,13 +22,7 @@ use mimes::{MediaType, get_media_type};
 use std::io::Write;
 use std::ops::Fn;
 
-impl Middleware for for<'a> fn(&mut Request, Response<'a>) -> MiddlewareResult<'a> {
-    fn invoke<'a, 'b>(&'a self, req: &mut Request<'b, 'a, 'b>, res: Response<'a>) -> MiddlewareResult<'a> {
-        (*self)(req, res)
-    }
-}
-
-impl Middleware for Box<for<'r, 'b, 'a> Fn(&'r mut Request<'b, 'a, 'b>, Response<'a>) -> MiddlewareResult<'a> + Send + Sync> {
+impl<T> Middleware for T where T: for<'r, 'b, 'a> Fn(&'r mut Request<'b, 'a, 'b>, Response<'a>) -> MiddlewareResult<'a> + Send + Sync + 'static {
     fn invoke<'a, 'b>(&'a self, req: &mut Request<'b, 'a, 'b>, res: Response<'a>) -> MiddlewareResult<'a> {
         (*self)(req, res)
     }

--- a/src/router/http_router.rs
+++ b/src/router/http_router.rs
@@ -18,21 +18,22 @@ pub trait HttpRouter {
     /// use regex::Regex;
     ///
     /// fn main() {
-    ///     let read_handler = middleware! { "Get request! "};
-    ///     let modify_handler = middleware! { |request|
-    ///         format!("Method is: {}", request.origin.method)
-    ///     };
-    ///
     ///     let mut server = Nickel::new();
     ///
-    ///     server.add_route(Get, "/foo", read_handler);
-    ///     server.add_route(Post, "/foo", modify_handler);
-    ///     server.add_route(Put, "/foo", modify_handler);
-    ///     server.add_route(Delete, "/foo", modify_handler);
+    ///     server.add_route(Get, "/foo", middleware! { "Get request! "});
+    ///     server.add_route(Post, "/foo", middleware! { |request|
+    ///         format!("Method is: {}", request.origin.method)
+    ///     });
+    ///     server.add_route(Put, "/foo", middleware! { |request|
+    ///         format!("Method is: {}", request.origin.method)
+    ///     });
+    ///     server.add_route(Delete, "/foo", middleware! { |request|
+    ///         format!("Method is: {}", request.origin.method)
+    ///     });
     ///
     ///     // Regex path
     ///     let regex = Regex::new("/(foo|bar)").unwrap();
-    ///     server.add_route(Get, regex, read_handler);
+    ///     server.add_route(Get, regex, middleware! { "Regex Get request! "});
     /// }
     /// ```
     fn add_route<M: Into<Matcher>, H: Middleware>(&mut self, Method, M, H);

--- a/src/router/router.rs
+++ b/src/router/router.rs
@@ -181,11 +181,10 @@ fn creates_valid_regex_for_routes () {
 #[test]
 fn can_match_var_routes () {
     let route_store = &mut Router::new();
-    let handler = middleware! { "hello from foo" };
 
-    route_store.add_route(Method::Get, "/foo/:userid", handler);
-    route_store.add_route(Method::Get, "/bar", handler);
-    route_store.add_route(Method::Get, "/file/:format/:file", handler);
+    route_store.add_route(Method::Get, "/foo/:userid", middleware! { "hello from foo" });
+    route_store.add_route(Method::Get, "/bar", middleware! { "hello from foo" });
+    route_store.add_route(Method::Get, "/file/:format/:file", middleware! { "hello from foo" });
 
     let route_result = route_store.match_route(&Method::Get, "/foo/4711").unwrap();
     assert_eq!(route_result.param("userid"), "4711");
@@ -249,10 +248,9 @@ fn regex_path() {
     use regex::Regex;
 
     let route_store = &mut Router::new();
-    let handler = middleware! { "hello from foo" };
 
     let regex = Regex::new("/(foo|bar)").unwrap();
-    route_store.add_route(Method::Get, regex, handler);
+    route_store.add_route(Method::Get, regex, middleware! { "hello from foo" });
 
     let route_result = route_store.match_route(&Method::Get, "/foo");
     assert!(route_result.is_some());
@@ -272,10 +270,9 @@ fn regex_path_named() {
     use regex::Regex;
 
     let route_store = &mut Router::new();
-    let handler = middleware! { "hello from foo" };
 
     let regex = Regex::new("/(?P<a>foo|bar)/b").unwrap();
-    route_store.add_route(Method::Get, regex, handler);
+    route_store.add_route(Method::Get, regex, middleware! { "hello from foo" });
 
     let route_result = route_store.match_route(&Method::Get, "/foo/b");
     assert!(route_result.is_some());
@@ -298,11 +295,10 @@ fn ignores_querystring() {
     use regex::Regex;
 
     let route_store = &mut Router::new();
-    let handler = middleware! { "hello from foo" };
 
     let regex = Regex::new("/(?P<a>foo|bar)/b").unwrap();
-    route_store.add_route(Method::Get, regex, handler);
-    route_store.add_route(Method::Get, "/:foo", handler);
+    route_store.add_route(Method::Get, regex, middleware! { "hello from foo" });
+    route_store.add_route(Method::Get, "/:foo", middleware! { "hello from foo" });
 
     // Should ignore the querystring
     let route_result = route_store.match_route(&Method::Get, "/moo?foo");


### PR DESCRIPTION
This is a bit of a compromise, allowing unboxed closures to be used for handlers but not for `Middleware`, while also making the routing a bit less flexible for the moment (can only take unboxed closures and not a `Middleware`, so you can't have a `Router` dispatch to another `Middleware` without wrapping a closure).

The second commit shows an alternative that I encountered while refactoring. If we deem macros acceptable in the time being we could follow that approach, as we maintain flexibility with only a minor syntactic wart. I favor this approach, but wanted to show how the example usage could look without any macros, which is the current state of the PR. Whenever https://github.com/rust-lang/rust/issues/24680 is fixed, we should then be able to depreciate the macro and the user code should be very easy to update `middleware! { |req, res| "foo" }` becomes `|_, res| res.send("foo")`.

Another alternative is to use `Fn(..)` as the bound everywhere in future when implementing unboxed closures for a type becomes stable, then the `Middleware` trait will become redundant and we could implement `Fn(..)` for `Router` and such. This approach doesn't help us with the current 1.0 feature-set though.