### PR TITLE
Allow middleware to bind response mutably

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -7,7 +7,7 @@ use std::io::Write;
 use nickel::status::StatusCode::{self, NotFound, BadRequest};
 use nickel::{
     Nickel, NickelError, Continue, Halt, Request,
-    QueryString, JsonBody, StaticFilesHandler, HttpRouter, Action
+    QueryString, JsonBody, StaticFilesHandler, HttpRouter, Action, MediaType
 };
 use regex::Regex;
 use rustc_serialize::json::{Json, ToJson};
@@ -48,6 +48,12 @@ fn main() {
 
     // go to http://localhost:6767/bar to see this route in action
     router.get("/bar", middleware!("This is the /bar handler"));
+
+    // go to http://localhost:6767/content-type to see this route in action
+    router.get("/content-type", middleware! { |request, mut response|
+        response.content_type(MediaType::Json);
+        "{'foo':'bar'}"
+    });
 
     let hello_regex = Regex::new("/hello/(?P<name>[a-zA-Z]+)").unwrap();
 


### PR DESCRIPTION
If they can't bind response mutably, they can't call &mut methods on the Response and set headers. Otherwise, to use `response.content_type()`, middleware creators must create a function instead of using the middleware! macro.