### PR TITLE
Fix instructions about nightly in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,7 @@ Then try `localhost:6767/user/4711` and `localhost:6767/bar`
 
 ### Note about nightly
 
-To build on nightly, you will need to add `--features nightly` to the end of the above commands. Alternatively, if depending on the library you will need to add the following to your `Cargo.toml`.
-
-```
-[dependencies.nickel]
-version = "*"
-features = ["nightly"]
-```
+You no longer need to add `--features nightly` to the end of the above commands or `features = ["nightly"]` to your `Cargo.toml`.
 
 ##Take a look at the example code
 Here is how sample server in `example.rs` looks like:


### PR DESCRIPTION
Nickel now builds and runs fine on nightly without the flag (in fact the flag gives an error) - I presume this is something to do with https://github.com/nickel-org/nickel.rs/pull/205?