### PR TITLE
Reword the readme and split contributor information into another file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,31 @@
-nickel.rs
-=======
-[![Build Status](https://travis-ci.org/nickel-org/nickel.rs.png?branch=master)](https://travis-ci.org/nickel-org/nickel.rs)
-[![](http://meritbadge.herokuapp.com/nickel)](https://crates.io/crates/nickel)
-[![Join the chat at https://gitter.im/nickel-org/nickel.rs](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/nickel-org/nickel.rs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+# [nickel.rs](http://nickel.rs) [![Build Status](https://travis-ci.org/nickel-org/nickel.rs.png?branch=master)](https://travis-ci.org/nickel-org/nickel.rs) [![](http://meritbadge.herokuapp.com/nickel)](https://crates.io/crates/nickel) [![Join the chat at https://gitter.im/nickel-org/nickel.rs](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/nickel-org/nickel.rs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-nickel is supposed to be a simple and lightweight foundation for web applications written in Rust. It's API is inspired by the popular express framework for JavaScript.
+[nickel.rs](http://nickel.rs) is a simple and lightweight foundation for web applications written in Rust. It's API is inspired by the popular express framework for JavaScript.
 
-Some of the features are:
+##Hello world
 
-* Easy handlers: A handler is just a function that takes a `&Request` and `&mut Response`
-* Variables in routes. Just write `my/route/:someid`
-* Easy parameter access: `request.param("someid")`
-* simple wildcard routes: `/some/*/route`
-* double wildcard routes: `/a/**/route`
-* middleware
-    * static file support
+### Dependencies
 
-##[Jump to the nickel.rs website](http://nickel.rs)
-
-#Getting started
-The easiest way to get started is to get the example running and play around with it. Let's do that real quick!
-
-##Clone the repository
-
-```shell
-git clone --recursive https://github.com/nickel-org/nickel.git
-```
-
-##Build nickel
-
-```shell
-cargo build --release
-```
-
-##Run the tests
-
-```shell
-cargo test
-```
-
-##Run the example
-
-```shell
-cargo run --example example
-```
-
-Then try `localhost:6767/user/4711` and `localhost:6767/bar`
-
-### Note about nightly
-
-To build on nightly, you will need to add `--features nightly` to the end of the above commands. Alternatively, if depending on the library you will need to add the following to your `Cargo.toml`.
+You'll need to create a *Cargo.toml* that looks like this;
 
 ```not_rust
+[package]
+
+name = "my-nickel-app"
+version = "0.0.1"
+authors = ["yourname"]
+
 [dependencies.nickel]
 version = "*"
 features = ["nightly"]
+
+[dependencies]
+rustc-serialize = "*"
 ```
 
-##Hello World!
-Here's a simple server, for a longer example check out the examples folder.
+### Code
+
+Add a file, *src/main.rs* that contains the following;
 
 ```rust,no_run
 #[macro_use] extern crate nickel;
@@ -78,20 +45,22 @@ fn main() {
 }
 ```
 
-##[Jump to the Full Documentation](http://nickel-org.github.io/nickel/)
+You can then compile this using *Cargo build* and run it using *Cargo run*. After it's running you should visit http://localhost:6767 to see your hello world!
+
+## More examples
+
+More examples can be found [in the examples directory](/examples/) and the full documentation can be [found here](http://nickel-org.github.io/nickel/).
 
 ##License
 
-Nickel is open source and licensed with the [MIT license](https://github.com/nickel-org/nickel/blob/master/LICENSE)
-
+[nickel.rs](http://nickel.rs) is open source and licensed with the [MIT license](https://github.com/nickel-org/nickel/blob/master/LICENSE)
 
 ##Contributing
 
-Nickel.rs is a community effort. We welcome new contributors with open arms.
-There is list of [open issues](https://github.com/nickel-org/nickel/issues?state=open) right here on github.
+[nickel.rs](http://nickel.rs) is a community effort. We welcome new contributors with open arms. Please read the [contributing guide here](/contributing.md) first.
+
+If you're looking for inspiration, there's list of [open issues](https://github.com/nickel-org/nickel/issues?state=open) right here on github. 
 
 If you need a helping hand reach out to [@cburgdorf](https://github.com/cburgdorf), [@Ryman](https://github.com/Ryman) or [@SimonPersson](https://github.com/SimonPersson).
-
-Make sure to follow this [commit message convention](https://github.com/ajoslin/conventional-changelog/blob/master/CONVENTIONS.md) because we will auto generate a changelog with [clog](https://github.com/thoughtram/clog) in the future.
 
 And hey, did you know you can also contribute by just starring the project here on github :)

--- a/README.md
+++ b/README.md
@@ -1,31 +1,8 @@
 # [nickel.rs](http://nickel.rs) [![Build Status](https://travis-ci.org/nickel-org/nickel.rs.png?branch=master)](https://travis-ci.org/nickel-org/nickel.rs) [![](http://meritbadge.herokuapp.com/nickel)](https://crates.io/crates/nickel) [![Join the chat at https://gitter.im/nickel-org/nickel.rs](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/nickel-org/nickel.rs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-[nickel.rs](http://nickel.rs) is a simple and lightweight foundation for web applications written in Rust. It's API is inspired by the popular express framework for JavaScript.
+[nickel.rs](http://nickel.rs) is a simple and lightweight foundation for web applications written in Rust. Its API is inspired by the popular express framework for JavaScript.
 
 ##Hello world
-
-### Dependencies
-
-You'll need to create a *Cargo.toml* that looks like this;
-
-```not_rust
-[package]
-
-name = "my-nickel-app"
-version = "0.0.1"
-authors = ["yourname"]
-
-[dependencies.nickel]
-version = "*"
-features = ["nightly"]
-
-[dependencies]
-rustc-serialize = "*"
-```
-
-### Code
-
-Add a file, *src/main.rs* that contains the following;
 
 ```rust,no_run
 #[macro_use] extern crate nickel;
@@ -45,6 +22,22 @@ fn main() {
 }
 ```
 
+### Dependencies
+
+You'll need to create a *Cargo.toml* that looks like this;
+
+```not_rust
+[package]
+
+name = "my-nickel-app"
+version = "0.0.1"
+authors = ["yourname"]
+
+[dependencies.nickel]
+version = "*"
+features = ["unstable"]
+```
+
 You can then compile this using *Cargo build* and run it using *Cargo run*. After it's running you should visit http://localhost:6767 to see your hello world!
 
 ## More examples
@@ -53,7 +46,7 @@ More examples can be found [in the examples directory](/examples/) and the full 
 
 ##License
 
-[nickel.rs](http://nickel.rs) is open source and licensed with the [MIT license](https://github.com/nickel-org/nickel/blob/master/LICENSE)
+[MIT license](https://github.com/nickel-org/nickel/blob/master/LICENSE)
 
 ##Contributing
 

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,35 @@
+# Contributing
+
+## Before you begin
+
+Make sure to follow this [commit message convention](https://github.com/ajoslin/conventional-changelog/blob/master/CONVENTIONS.md) because we will auto generate a changelog with [clog](https://github.com/thoughtram/clog) in the future.
+
+# Getting started
+
+The easiest way to get started is to get nickel running and play around with it. Let's do that real quick!
+
+##Clone the repository
+
+```shell
+git clone https://github.com/nickel-org/nickel.git
+```
+
+##Build nickel
+
+```shell
+cargo build --release
+```
+
+##Run the tests
+
+```shell
+cargo test
+```
+
+##Run the example
+
+```shell
+cargo run --example example
+```
+
+Then try `localhost:6767/user/4711` and `localhost:6767/bar`.


### PR DESCRIPTION
#159 was the original source of this, but I remembered finding it quite hard to understand the readme before because it contains a lot of information on various aspects of nickel development, imo all it really needs to have is a status, how to helloworld and where to find out more. 

I appreciate the readme is pretty subjective and am not suggesting this PR be accepted entirely as is - I'm open to changing it up