### PR TITLE
Update macro_example.rs

### DIFF
--- a/examples/macro_example.rs
+++ b/examples/macro_example.rs
@@ -92,7 +92,7 @@ fn main() {
             "This matches /some/crazy/route but not /some/super/crazy/route"
         }
 
-        // go to http://localhost:6767/some/crazy/route to see this route in action
+        // go to http://localhost:6767/a/some/crazy/route to see this route in action
         get "/a/**/route" => |request, response| {
             "This matches /a/crazy/route and also /a/super/crazy/route"
         }


### PR DESCRIPTION
docs(example): Fixed missing url fragment on example's comment

fixes example's comment that leads people to a wrong url. It is missing a "a/"