### PR TITLE
fix(static_files): ignore the querystring during static file lookup

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -2,6 +2,7 @@ use router::RouteResult;
 use plugin::{Extensible, Pluggable};
 use typemap::TypeMap;
 use hyper::server::Request as HyperRequest;
+use hyper::uri::RequestUri::AbsolutePath;
 
 ///A container for all the request data
 pub struct Request<'a, 'b: 'k, 'k: 'a> {
@@ -24,6 +25,13 @@ impl<'a, 'b, 'k> Request<'a, 'b, 'k> {
 
     pub fn param(&self, key: &str) -> &str {
         self.route_result.as_ref().unwrap().param(key)
+    }
+
+    pub fn path_without_query(&self) -> Option<&str> {
+        match self.origin.uri {
+            AbsolutePath(ref path) => Some(path.splitn(2, '?').next().unwrap()),
+            _ => None
+        }
     }
 }
 

--- a/src/router/router.rs
+++ b/src/router/router.rs
@@ -1,5 +1,5 @@
 use middleware::{Middleware, Continue, MiddlewareResult};
-use hyper::uri::RequestUri::AbsolutePath;
+
 use request::Request;
 use response::Response;
 use router::HttpRouter;
@@ -54,9 +54,6 @@ impl Router {
     }
 
     pub fn match_route<'a>(&'a self, method: &Method, path: &str) -> Option<RouteResult<'a>> {
-        // Strip off the querystring when matching a route
-        let path = path.splitn(2, '?').next().unwrap();
-
         self.routes
             .iter()
             .find(|item| item.method == *method && item.matcher.is_match(path))
@@ -98,10 +95,11 @@ impl Middleware for Router {
     fn invoke<'a, 'b>(&'a self, req: &mut Request<'b, 'a, 'b>, mut res: Response<'a>)
                         -> MiddlewareResult<'a> {
         debug!("Router::invoke for '{:?}'", req.origin.uri);
-        let route_result = match req.origin.uri {
-            AbsolutePath(ref url) => self.match_route(&req.origin.method, &**url),
-            _ => None
-        };
+
+        // Strip off the querystring when matching a route
+        let route_result = req.path_without_query()
+                              .and_then(|path| self.match_route(&req.origin.method, path));
+
         debug!("route_result.route.path: {:?}", route_result.as_ref().map(|r| r.route.matcher.path()));
 
         match route_result {

--- a/src/static_files_handler.rs
+++ b/src/static_files_handler.rs
@@ -2,7 +2,6 @@ use std::path::{Path, PathBuf};
 use std::io::ErrorKind::NotFound;
 use std::fs;
 
-use hyper::uri::RequestUri::AbsolutePath;
 use hyper::method::Method::{Get, Head};
 
 use request::Request;
@@ -45,17 +44,14 @@ impl StaticFilesHandler {
     }
 
     fn extract_path<'a>(&self, req: &'a mut Request) -> Option<&'a str> {
-        match req.origin.uri {
-            AbsolutePath(ref path) => {
-                debug!("{:?} {:?}{:?}", req.origin.method, self.root_path.display(), path);
+        req.path_without_query().map(|path| {
+            debug!("{:?} {:?}{:?}", req.origin.method, self.root_path.display(), path);
 
-                match &**path {
-                    "/" => Some("index.html"),
-                    path => Some(&path[1..]),
-                }
+            match path {
+                "/" => "index.html",
+                path => &path[1..],
             }
-            _ => None
-        }
+        })
     }
 
     fn with_file<'a, 'b, P>(&self,

--- a/tests/compile-fail/inference_request_hinted.rs
+++ b/tests/compile-fail/inference_request_hinted.rs
@@ -11,9 +11,11 @@ fn main() {
     // Request hinted
     server.utilize(|_: &mut Request, res| res.send("Hello World!"));
     //~^ ERROR the type of this value must be known in this context
+    //~^^ ERROR type mismatch resolving `for<'r,'b,'a>
 
     server.get("**", |_: &mut Request, res| res.send("Hello World!"));
     //~^ ERROR the type of this value must be known in this context
+    //~^^ ERROR type mismatch resolving `for<'r,'b,'a>
 
     server.listen("127.0.0.1:6767");
 }


### PR DESCRIPTION
Fixes #224 