### PR TITLE
fix(request): request.param(_) now returns an Option

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -43,7 +43,7 @@ fn main() {
 
     // go to http://localhost:6767/user/4711 to see this route in action
     router.get("/user/:userid", middleware! { |request|
-        format!("This is user: {}", request.param("userid"))
+        format!("This is user: {}", request.param("userid").unwrap())
     });
 
     // go to http://localhost:6767/bar to see this route in action
@@ -59,7 +59,7 @@ fn main() {
 
     // go to http://localhost:6767/hello/moomah to see this route in action
     router.get(hello_regex, middleware! { |request|
-        format!("Hello {}", request.param("name"))
+        format!("Hello {}", request.param("name").unwrap())
     });
 
     // go to http://localhost:6767/some/crazy/route to see this route in action

--- a/examples/example_with_default_router.rs
+++ b/examples/example_with_default_router.rs
@@ -10,7 +10,7 @@ fn main() {
 
     // go to http://localhost:6767/foo to see this route in action
     server.get("/:foo", middleware! { |request|
-        format!("Foo is '{}'", request.param("foo"))
+        format!("Foo is '{}'", request.param("foo").unwrap())
     });
 
     server.listen("127.0.0.1:6767");

--- a/examples/macro_example.rs
+++ b/examples/macro_example.rs
@@ -52,13 +52,13 @@ fn main() {
         // go to http://localhost:6767/user/4711 to see this route in action
         get "/user/:userid" => |request| {
             // returning a String
-            format!("This is user: {}", request.param("userid"))
+            format!("This is user: {}", request.param("userid").unwrap())
         }
 
         // go to http://localhost:6767/no_alloc/4711 to see this route in action
         get "/no_alloc/:userid" => |request, response| {
             // returning a slice of T where T: Display
-            &["This is user: ", request.param("userid")][..]
+            &["This is user: ", request.param("userid").unwrap()][..]
         }
 
         // go to http://localhost:6767/bar to see this route in action
@@ -75,7 +75,7 @@ fn main() {
 
         // go to http://localhost:6767/hello/moomah to see this route in action
         get hello_regex => |request| {
-            format!("Hello {}", request.param("name"))
+            format!("Hello {}", request.param("name").unwrap())
         }
 
         // go to http://localhost:6767/redirect to see this route in action

--- a/src/request.rs
+++ b/src/request.rs
@@ -23,7 +23,7 @@ impl<'a, 'b, 'k> Request<'a, 'b, 'k> {
         }
     }
 
-    pub fn param(&self, key: &str) -> &str {
+    pub fn param(&self, key: &str) -> Option<&str> {
         self.route_result.as_ref().unwrap().param(key)
     }
 

--- a/src/router/http_router.rs
+++ b/src/router/http_router.rs
@@ -59,7 +59,7 @@ pub trait HttpRouter {
     ///
     ///     // with variables
     ///     server.get("/user/:userid", middleware! { |request|
-    ///         format!("This is user: {}", request.param("userid"))
+    ///         format!("This is user: {}", request.param("userid").unwrap())
     ///     });
     ///
     ///     // with simple wildcard
@@ -88,7 +88,7 @@ pub trait HttpRouter {
     ///         }
     ///         // with variables
     ///         get "/user/:userid" => |request, response| {
-    ///             format!("This is user: {}", request.param("userid"))
+    ///             format!("This is user: {}", request.param("userid").unwrap())
     ///         }
     ///         // with simple wildcard
     ///         get "/user/*/:userid" => |request, response| {


### PR DESCRIPTION
A user may wish to use the same handler for multiple routes,
if the behaviour of such a handler should differ based on the
available params then the handler it will panic at runtime as
there is no convenient way to check for the presence of the
param before accessing it.

For broken code:
If you have `foo.param("bar")` then you'll need to `unwrap` the
Option, e.g. `foo.param("bar").unwrap()`.

[breaking-change]