### PR TITLE
Cookies #2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ groupable = "*"
 mustache = "*"
 lazy_static = "*"
 modifier = "*"
+cookie = "*"
 
 [dependencies.compiletest_rs]
 version = "*"
@@ -37,6 +38,11 @@ optional = true
 
 name = "example"
 path = "examples/example.rs"
+
+[[example]]
+
+name = "cookies_example"
+path = "examples/cookies_example.rs"
 
 [[example]]
 

--- a/examples/cookies_example.rs
+++ b/examples/cookies_example.rs
@@ -1,0 +1,28 @@
+#[macro_use] extern crate nickel;
+extern crate cookie;
+
+use nickel::{Nickel, HttpRouter, Cookies};
+use nickel::cookies;
+
+struct Data {
+    secret_key: cookies::SecretKey
+}
+
+impl AsRef<cookies::SecretKey> for Data {
+    fn as_ref(&self) -> &cookies::SecretKey {
+        &self.secret_key
+    }
+}
+
+fn main() {
+    let data = Data { secret_key: cookies::SecretKey([0; 32]) };
+    let mut server = Nickel::with_data(data);
+
+    // Try curl -b MyCookie=bar localhost:6767
+    server.get("/", middleware! { |req|
+        let cookie = req.cookies().find("MyCookie");
+        format!("MyCookie={:?}", cookie.map(|c| c.value))
+    });
+
+    server.listen("127.0.0.1:6767");
+}

--- a/examples/cookies_example.rs
+++ b/examples/cookies_example.rs
@@ -1,7 +1,7 @@
 #[macro_use] extern crate nickel;
 extern crate cookie;
 
-use nickel::{Nickel, HttpRouter, Cookies, CookiesMut, QueryString};
+use nickel::{Nickel, HttpRouter, Cookies, QueryString};
 use nickel::cookies;
 use cookie::Cookie;
 

--- a/examples/cookies_example.rs
+++ b/examples/cookies_example.rs
@@ -1,8 +1,9 @@
 #[macro_use] extern crate nickel;
 extern crate cookie;
 
-use nickel::{Nickel, HttpRouter, Cookies};
+use nickel::{Nickel, HttpRouter, Cookies, CookiesMut, QueryString};
 use nickel::cookies;
+use cookie::Cookie;
 
 struct Data {
     secret_key: cookies::SecretKey
@@ -22,6 +23,22 @@ fn main() {
     server.get("/", middleware! { |req|
         let cookie = req.cookies().find("MyCookie");
         format!("MyCookie={:?}", cookie.map(|c| c.value))
+    });
+
+    // Note: Don't use get for login in real applications ;)
+    // Try http://localhost:6767/login?name=foo
+    server.get("/login", middleware! { |req, mut res|
+        let jar = res.cookies_mut()
+                     // long life cookies!
+                     .permanent();
+
+        let name = req.query().get("name")
+                              .unwrap_or("default_name");
+        let cookie = Cookie::new("MyCookie".to_owned(),
+                                 name.to_owned());
+        jar.add(cookie);
+
+        "Cookie set!"
     });
 
     server.listen("127.0.0.1:6767");

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -113,7 +113,7 @@ fn main() {
     server.utilize(StaticFilesHandler::new("examples/assets/"));
 
     //this is how to overwrite the default error handler to handle 404 cases with a custom view
-    fn custom_404<'a>(err: &mut NickelError, _req: &mut Request) -> Action {
+    fn custom_404<'a, D>(err: &mut NickelError<D>, _req: &mut Request<D>) -> Action {
         if let Some(ref mut res) = err.stream {
             if res.status() == NotFound {
                 let _ = res.write_all(b"<h1>Call the police!</h1>");
@@ -126,7 +126,7 @@ fn main() {
 
 
     // issue #20178
-    let custom_handler: fn(&mut NickelError, &mut Request) -> Action = custom_404;
+    let custom_handler: fn(&mut NickelError<()>, &mut Request<()>) -> Action = custom_404;
 
     server.handle_error(custom_handler);
 

--- a/examples/macro_example.rs
+++ b/examples/macro_example.rs
@@ -19,13 +19,13 @@ struct Person {
 }
 
 //this is an example middleware function that just logs each request
-fn logger<'a>(request: &mut Request, response: Response<'a>) -> MiddlewareResult<'a> {
+fn logger<'a, D>(request: &mut Request<D>, response: Response<'a, D>) -> MiddlewareResult<'a, D> {
     println!("logging request: {:?}", request.origin.uri);
     Ok(Continue(response))
 }
 
 //this is how to overwrite the default error handler to handle 404 cases with a custom view
-fn custom_404<'a>(err: &mut NickelError, _req: &mut Request) -> Action {
+fn custom_404<'a, D>(err: &mut NickelError<D>, _req: &mut Request<D>) -> Action {
     if let Some(ref mut res) = err.stream {
         if res.status() == NotFound {
             let _ = res.write_all(b"<h1>Call the police!</h1>");
@@ -122,7 +122,7 @@ fn main() {
     ));
 
     // issue #20178
-    let custom_handler: fn(&mut NickelError, &mut Request) -> Action = custom_404;
+    let custom_handler: fn(&mut NickelError<()>, &mut Request<()>) -> Action = custom_404;
 
     server.handle_error(custom_handler);
 

--- a/src/cookies.rs
+++ b/src/cookies.rs
@@ -1,4 +1,4 @@
-use request::Request;
+use {Request, Response};
 use plugin::{Plugin, Pluggable};
 use typemap::Key;
 use hyper::header;
@@ -34,5 +34,35 @@ impl<'a, 'b, 'k, D> Cookies for Request<'a, 'b, 'k, D>
         where D: AsRef<SecretKey> {
     fn cookies(&mut self) -> &CookieJar {
         self.get_ref::<CookiePlugin>().unwrap()
+    }
+}
+
+impl<'a, 'b, 'k, D> Plugin<Response<'a, D>> for CookiePlugin
+        where D: AsRef<SecretKey> {
+    type Error = ();
+
+    fn eval(res: &mut Response<'a, D>) -> Result<CookieJar<'static>, ()> {
+        // Schedule the cookie to be written when headers are being sent
+        res.on_send(|res| {
+            let header = {
+                let jar = res.get_ref::<CookiePlugin>().unwrap();
+                header::SetCookie::from_cookie_jar(jar)
+            };
+            res.set(header);
+        });
+
+        let key = res.data().as_ref();
+        Ok(CookieJar::new(&key.0))
+    }
+}
+
+pub trait CookiesMut {
+    fn cookies_mut(&mut self) -> &mut CookieJar<'static>;
+}
+
+impl<'a, D> CookiesMut for Response<'a, D>
+        where D: AsRef<SecretKey> {
+    fn cookies_mut(&mut self) -> &mut CookieJar<'static> {
+        self.get_mut::<CookiePlugin>().unwrap()
     }
 }

--- a/src/cookies.rs
+++ b/src/cookies.rs
@@ -1,0 +1,38 @@
+use request::Request;
+use plugin::{Plugin, Pluggable};
+use typemap::Key;
+use hyper::header;
+
+use cookie::CookieJar;
+
+pub struct SecretKey(pub [u8; 32]);
+
+// Plugin boilerplate
+struct CookiePlugin;
+impl Key for CookiePlugin { type Value = CookieJar<'static>; }
+
+impl<'a, 'b, 'k, D> Plugin<Request<'a, 'b, 'k, D>> for CookiePlugin
+        where D: AsRef<SecretKey> {
+    type Error = ();
+
+    fn eval(req: &mut Request<D>) -> Result<CookieJar<'static>, ()> {
+        let key = req.data().as_ref();
+        let jar = match req.origin.headers.get::<header::Cookie>() {
+            Some(c) => c.to_cookie_jar(&key.0),
+            None => CookieJar::new(&key.0)
+        };
+
+        Ok(jar)
+    }
+}
+
+pub trait Cookies {
+    fn cookies(&mut self) -> &CookieJar;
+}
+
+impl<'a, 'b, 'k, D> Cookies for Request<'a, 'b, 'k, D>
+        where D: AsRef<SecretKey> {
+    fn cookies(&mut self) -> &CookieJar {
+        self.get_ref::<CookiePlugin>().unwrap()
+    }
+}

--- a/src/cookies.rs
+++ b/src/cookies.rs
@@ -1,5 +1,5 @@
 use {Request, Response};
-use plugin::{Plugin, Pluggable};
+use plugin::{Plugin, Pluggable, Extensible};
 use typemap::Key;
 use hyper::header;
 
@@ -26,17 +26,6 @@ impl<'a, 'b, 'k, D> Plugin<Request<'a, 'b, 'k, D>> for CookiePlugin
     }
 }
 
-pub trait Cookies {
-    fn cookies(&mut self) -> &CookieJar;
-}
-
-impl<'a, 'b, 'k, D> Cookies for Request<'a, 'b, 'k, D>
-        where D: AsRef<SecretKey> {
-    fn cookies(&mut self) -> &CookieJar {
-        self.get_ref::<CookiePlugin>().unwrap()
-    }
-}
-
 impl<'a, 'b, 'k, D> Plugin<Response<'a, D>> for CookiePlugin
         where D: AsRef<SecretKey> {
     type Error = ();
@@ -56,13 +45,36 @@ impl<'a, 'b, 'k, D> Plugin<Response<'a, D>> for CookiePlugin
     }
 }
 
-pub trait CookiesMut {
-    fn cookies_mut(&mut self) -> &mut CookieJar<'static>;
-}
+/// Trait to whitelist access to `&'mut CookieJar` via the `Cookies` trait.
+pub trait AllowMutCookies {}
+impl<'a, D> AllowMutCookies for Response<'a, D> {}
 
-impl<'a, D> CookiesMut for Response<'a, D>
-        where D: AsRef<SecretKey> {
-    fn cookies_mut(&mut self) -> &mut CookieJar<'static> {
+/// Provides access to a `CookieJar`.
+///
+/// Access to cookies for a `Request` is read-only and represents the cookies
+/// sent from the client.
+///
+/// The `Response` has access to a mutable `CookieJar` when first accessed.
+/// Any cookies added to this jar will be sent as `Set-Cookie` response headers
+/// when the `Response` sends it's `Headers` to the client.
+///
+/// #Examples
+/// See `examples/cookies_example.rs`.
+pub trait Cookies : Pluggable + Extensible
+        where CookiePlugin: Plugin<Self, Value=CookieJar<'static>, Error=()> {
+    /// Provides access to an immutable CookieJar.
+    ///
+    /// Currently requires a mutable reciever, hopefully this can change in future.
+    fn cookies(&mut self) -> &CookieJar {
+        self.get_ref::<CookiePlugin>().unwrap()
+    }
+
+    /// Provides access to a mutable CookieJar.
+    fn cookies_mut(&mut self) -> &mut CookieJar<'static> where Self: AllowMutCookies {
         self.get_mut::<CookiePlugin>().unwrap()
     }
 }
+
+impl<'a, 'b, 'k, D: AsRef<SecretKey>> Cookies for Request<'a, 'b, 'k, D> {}
+
+impl<'a, D: AsRef<SecretKey>> Cookies for Response<'a, D> {}

--- a/src/default_error_handler.rs
+++ b/src/default_error_handler.rs
@@ -7,8 +7,8 @@ use std::io::Write;
 #[derive(Clone, Copy)]
 pub struct DefaultErrorHandler;
 
-impl ErrorHandler for DefaultErrorHandler {
-    fn handle_error(&self, err: &mut NickelError, _req: &mut Request) -> Action {
+impl<D> ErrorHandler<D> for DefaultErrorHandler {
+    fn handle_error(&self, err: &mut NickelError<D>, _req: &mut Request<D>) -> Action {
         if let Some(ref mut res) = err.stream {
             let msg : &[u8] = match res.status() {
                 NotFound => b"Not Found",

--- a/src/json_body_parser.rs
+++ b/src/json_body_parser.rs
@@ -8,10 +8,10 @@ use std::io::{Read, ErrorKind};
 // Plugin boilerplate
 struct JsonBodyParser;
 impl Key for JsonBodyParser { type Value = String; }
-impl<'a, 'b, 'k> Plugin<Request<'a, 'b, 'k>> for JsonBodyParser {
+impl<'a, 'b, 'k, D> Plugin<Request<'a, 'b, 'k, D>> for JsonBodyParser {
     type Error = io::Error;
 
-    fn eval(req: &mut Request) -> Result<String, io::Error> {
+    fn eval(req: &mut Request<D>) -> Result<String, io::Error> {
         let mut s = String::new();
         try!(req.origin.read_to_string(&mut s));
         Ok(s)
@@ -22,7 +22,7 @@ pub trait JsonBody {
     fn json_as<T: Decodable>(&mut self) -> Result<T, io::Error>;
 }
 
-impl<'a, 'b, 'k> JsonBody for Request<'a, 'b, 'k> {
+impl<'a, 'b, 'k, D> JsonBody for Request<'a, 'b, 'k, D> {
     fn json_as<T: Decodable>(&mut self) -> Result<T, io::Error> {
         self.get_ref::<JsonBodyParser>().and_then(|parsed|
             json::decode::<T>(&*parsed).map_err(|err|

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ extern crate url;
 extern crate mustache;
 extern crate groupable;
 extern crate modifier;
+extern crate cookie;
 
 #[macro_use] extern crate log;
 #[macro_use] extern crate lazy_static;
@@ -39,6 +40,7 @@ pub use router::{Router, Route, RouteResult, HttpRouter};
 pub use nickel_error::NickelError;
 pub use mimes::MediaType;
 pub use responder::Responder;
+pub use cookies::Cookies;
 
 #[macro_use] pub mod macros;
 
@@ -57,6 +59,7 @@ mod query_string;
 mod urlencoded;
 mod nickel_error;
 mod default_error_handler;
+pub mod cookies;
 
 pub mod status {
     pub use hyper::status::StatusCode;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub use router::{Router, Route, RouteResult, HttpRouter};
 pub use nickel_error::NickelError;
 pub use mimes::MediaType;
 pub use responder::Responder;
-pub use cookies::{Cookies, CookiesMut};
+pub use cookies::Cookies;
 
 #[macro_use] pub mod macros;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub use router::{Router, Route, RouteResult, HttpRouter};
 pub use nickel_error::NickelError;
 pub use mimes::MediaType;
 pub use responder::Responder;
-pub use cookies::Cookies;
+pub use cookies::{Cookies, CookiesMut};
 
 #[macro_use] pub mod macros;
 

--- a/src/macros/middleware.rs
+++ b/src/macros/middleware.rs
@@ -38,18 +38,18 @@ macro_rules! _middleware_inner {
         use $crate::{MiddlewareResult,Responder, Response, Request};
 
         #[inline(always)]
-        fn restrict<'a, R: Responder>(r: R, res: Response<'a>)
-                -> MiddlewareResult<'a> {
+        fn restrict<'a, D, R: Responder<D>>(r: R, res: Response<'a, D>)
+                -> MiddlewareResult<'a, D> {
             res.send(r)
         }
 
         // Inference fails due to thinking it's a (&Request, Response) with
         // different mutability requirements
         #[inline(always)]
-        fn restrict_closure<F>(f: F) -> F
+        fn restrict_closure<F, D>(f: F) -> F
             where F: for<'r, 'b, 'a>
-                        Fn(&'r mut Request<'b, 'a, 'b>, Response<'a>)
-                            -> MiddlewareResult<'a> + Send + Sync { f }
+                        Fn(&'r mut Request<'b, 'a, 'b, D>, Response<'a, D>)
+                            -> MiddlewareResult<'a, D> + Send + Sync { f }
 
         restrict_closure(move |as_pat!($req), $res_binding| {
             restrict(as_block!({$($b)+}), $res)

--- a/src/query_string.rs
+++ b/src/query_string.rs
@@ -33,10 +33,10 @@ impl Query {
 struct QueryStringParser;
 impl Key for QueryStringParser { type Value = Query; }
 
-impl<'a, 'b, 'k> Plugin<Request<'a, 'b, 'k>> for QueryStringParser {
+impl<'a, 'b, 'k, D> Plugin<Request<'a, 'b, 'k, D>> for QueryStringParser {
     type Error = ();
 
-    fn eval(req: &mut Request) -> Result<Query, ()> {
+    fn eval(req: &mut Request<D>) -> Result<Query, ()> {
         Ok(parse(&req.origin.uri))
     }
 }
@@ -46,7 +46,7 @@ pub trait QueryString {
     fn query(&mut self) -> &Query;
 }
 
-impl<'a, 'b, 'k> QueryString for Request<'a, 'b, 'k> {
+impl<'a, 'b, 'k, D> QueryString for Request<'a, 'b, 'k, D> {
     fn query(&mut self) -> &Query {
         self.get_ref::<QueryStringParser>()
             .ok()

--- a/src/request.rs
+++ b/src/request.rs
@@ -12,9 +12,9 @@ pub struct Request<'a, 'b: 'k, 'k: 'a, D: 'b> {
     ///a `HashMap<String, String>` holding all params with names and values
     pub route_result: Option<RouteResult<'b, D>>,
 
-    map: TypeMap,
-
     data: &'a D,
+
+    map: TypeMap,
 }
 
 impl<'a, 'b, 'k, D> Request<'a, 'b, 'k, D> {
@@ -37,6 +37,10 @@ impl<'a, 'b, 'k, D> Request<'a, 'b, 'k, D> {
             AbsolutePath(ref path) => Some(path.splitn(2, '?').next().unwrap()),
             _ => None
         }
+    }
+
+    pub fn data(&self) -> &D {
+        &self.data
     }
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -4,22 +4,27 @@ use typemap::TypeMap;
 use hyper::server::Request as HyperRequest;
 use hyper::uri::RequestUri::AbsolutePath;
 
+//FIXME: Choose better lifetime names
 ///A container for all the request data
-pub struct Request<'a, 'b: 'k, 'k: 'a> {
+pub struct Request<'a, 'b: 'k, 'k: 'a, D: 'b> {
     ///the original `hyper::server::Request`
     pub origin: HyperRequest<'a, 'k>,
     ///a `HashMap<String, String>` holding all params with names and values
-    pub route_result: Option<RouteResult<'b>>,
+    pub route_result: Option<RouteResult<'b, D>>,
 
-    map: TypeMap
+    map: TypeMap,
+
+    data: &'a D,
 }
 
-impl<'a, 'b, 'k> Request<'a, 'b, 'k> {
-    pub fn from_internal(req: HyperRequest<'a, 'k>) -> Request<'a, 'b, 'k> {
+impl<'a, 'b, 'k, D> Request<'a, 'b, 'k, D> {
+    pub fn from_internal(req: HyperRequest<'a, 'k>,
+                         data: &'a D) -> Request<'a, 'b, 'k, D> {
         Request {
             origin: req,
             route_result: None,
-            map: TypeMap::new()
+            map: TypeMap::new(),
+            data: data
         }
     }
 
@@ -35,7 +40,7 @@ impl<'a, 'b, 'k> Request<'a, 'b, 'k> {
     }
 }
 
-impl<'a, 'b, 'k> Extensible for Request<'a, 'b, 'k> {
+impl<'a, 'b, 'k, D> Extensible for Request<'a, 'b, 'k, D> {
     fn extensions(&self) -> &TypeMap {
         &self.map
     }
@@ -45,4 +50,4 @@ impl<'a, 'b, 'k> Extensible for Request<'a, 'b, 'k> {
     }
 }
 
-impl<'a, 'b, 'k> Pluggable for Request<'a, 'b, 'k> {}
+impl<'a, 'b, 'k, D> Pluggable for Request<'a, 'b, 'k, D> {}

--- a/src/response.rs
+++ b/src/response.rs
@@ -23,19 +23,22 @@ use modifier::Modifier;
 pub type TemplateCache = RwLock<HashMap<String, Template>>;
 
 ///A container for the response
-pub struct Response<'a, T: 'static + Any = Fresh> {
+pub struct Response<'a, D: 'a, T: 'static + Any = Fresh> {
     ///the original `hyper::server::Response`
     origin: HyperResponse<'a, T>,
-    templates: &'a TemplateCache
+    templates: &'a TemplateCache,
+    data: &'a D,
 }
 
-impl<'a> Response<'a, Fresh> {
+impl<'a, D> Response<'a, D, Fresh> {
     pub fn from_internal<'c, 'd>(response: HyperResponse<'c, Fresh>,
-                                 templates: &'c TemplateCache)
-                                -> Response<'c, Fresh> {
+                                 templates: &'c TemplateCache,
+                                 data: &'c D)
+                                -> Response<'c, D, Fresh> {
         Response {
             origin: response,
-            templates: templates
+            templates: templates,
+            data: data
         }
     }
 
@@ -81,7 +84,7 @@ impl<'a> Response<'a, Fresh> {
     ///     // ...
     /// }
     /// ```
-    pub fn set<T: Modifier<Response<'a>>>(&mut self, attribute: T) -> &mut Response<'a> {
+    pub fn set<T: Modifier<Response<'a, D>>>(&mut self, attribute: T) -> &mut Response<'a, D> {
         attribute.modify(self);
         self
     }
@@ -92,12 +95,12 @@ impl<'a> Response<'a, Fresh> {
     /// ```{rust}
     /// use nickel::{Request, Response, MiddlewareResult, Halt};
     ///
-    /// fn handler<'a>(_: &mut Request, res: Response<'a>) -> MiddlewareResult<'a> {
+    /// fn handler<'a, D>(_: &mut Request<D>, res: Response<'a, D>) -> MiddlewareResult<'a, D> {
     ///     res.send("hello world")
     /// }
     /// ```
     #[inline]
-    pub fn send<T: Responder>(self, data: T) -> MiddlewareResult<'a> {
+    pub fn send<T: Responder<D>>(self, data: T) -> MiddlewareResult<'a, D> {
         data.respond(self)
     }
 
@@ -109,12 +112,12 @@ impl<'a> Response<'a, Fresh> {
     /// use nickel::status::StatusCode;
     /// use std::path::Path;
     ///
-    /// fn handler<'a>(_: &mut Request, mut res: Response<'a>) -> MiddlewareResult<'a> {
+    /// fn handler<'a, D>(_: &mut Request<D>, mut res: Response<'a, D>) -> MiddlewareResult<'a, D> {
     ///     let favicon = Path::new("/assets/favicon.ico");
     ///     res.send_file(favicon)
     /// }
     /// ```
-    pub fn send_file(mut self, path: &Path) -> MiddlewareResult<'a> {
+    pub fn send_file(mut self, path: &Path) -> MiddlewareResult<'a, D> {
         // Chunk the response
         self.origin.headers_mut().remove::<ContentLength>();
         // Determine content type by file extension or default to binary
@@ -145,7 +148,7 @@ impl<'a> Response<'a, Fresh> {
 
     /// Return an error with the appropriate status code for error handlers to
     /// provide output for.
-    pub fn error<T>(self, status: StatusCode, message: T) -> MiddlewareResult<'a>
+    pub fn error<T>(self, status: StatusCode, message: T) -> MiddlewareResult<'a, D>
             where T: Into<Cow<'static, str>> {
         Err(NickelError::new(self, message, status))
     }
@@ -191,16 +194,16 @@ impl<'a> Response<'a, Fresh> {
     /// use std::collections::HashMap;
     /// use nickel::{Request, Response, MiddlewareResult, Halt};
     ///
-    /// fn handler<'a>(_: &mut Request, mut res: Response<'a>) -> MiddlewareResult<'a> {
+    /// fn handler<'a, D>(_: &mut Request<D>, mut res: Response<'a, D>) -> MiddlewareResult<'a, D> {
     ///     let mut data = HashMap::new();
     ///     data.insert("name", "user");
     ///     res.render("examples/assets/template.tpl", &data)
     /// }
     /// ```
-    pub fn render<T, P>(self, path: P, data: &T) -> MiddlewareResult<'a>
+    pub fn render<T, P>(self, path: P, data: &T) -> MiddlewareResult<'a, D>
             where T: Encodable, P: AsRef<str> + Into<String> {
-        fn render<'a, T>(res: Response<'a>, template: &Template, data: &T)
-                -> MiddlewareResult<'a> where T: Encodable {
+        fn render<'a, D, T>(res: Response<'a, D>, template: &Template, data: &T)
+                -> MiddlewareResult<'a, D> where T: Encodable {
             let mut stream = try!(res.start());
             match template.render(&mut stream, data) {
                 Ok(()) => Ok(Halt(stream)),
@@ -235,12 +238,18 @@ impl<'a> Response<'a, Fresh> {
         render(self, template, data)
     }
 
-    pub fn start(mut self) -> Result<Response<'a, Streaming>, NickelError<'a>> {
+    pub fn start(mut self) -> Result<Response<'a, D, Streaming>, NickelError<'a, D>> {
         self.set_fallback_headers();
 
-        let Response { origin, templates } = self;
+        let Response { origin, templates, data } = self;
         match origin.start() {
-            Ok(origin) => Ok(Response { origin: origin, templates: templates }),
+            Ok(origin) => {
+                Ok(Response {
+                    origin: origin,
+                    templates: templates,
+                    data: data
+                })
+            },
             Err(e) =>
                 unsafe {
                     Err(NickelError::without_response(format!("Failed to start response: {}", e)))
@@ -249,7 +258,7 @@ impl<'a> Response<'a, Fresh> {
     }
 }
 
-impl<'a, 'b> Write for Response<'a, Streaming> {
+impl<'a, 'b, D> Write for Response<'a, D, Streaming> {
     #[inline(always)]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.origin.write(buf)
@@ -261,12 +270,12 @@ impl<'a, 'b> Write for Response<'a, Streaming> {
     }
 }
 
-impl<'a, 'b> Response<'a, Streaming> {
+impl<'a, 'b, D> Response<'a, D, Streaming> {
     /// In the case of an unrecoverable error while a stream is already in
     /// progress, there is no standard way to signal to the client that an
     /// error has occurred. `bail` will drop the connection and log an error
     /// message.
-    pub fn bail<T>(self, message: T) -> MiddlewareResult<'a>
+    pub fn bail<T>(self, message: T) -> MiddlewareResult<'a, D>
             where T: Into<Cow<'static, str>> {
         let _ = self.end();
         unsafe { Err(NickelError::without_response(message)) }
@@ -278,7 +287,7 @@ impl<'a, 'b> Response<'a, Streaming> {
     }
 }
 
-impl <'a, T: 'static + Any> Response<'a, T> {
+impl <'a, D, T: 'static + Any> Response<'a, D, T> {
     /// The status of this response.
     pub fn status(&self) -> StatusCode {
         self.origin.status()
@@ -311,14 +320,14 @@ mod modifier_impls {
     use modifier::Modifier;
     use {Response, MediaType};
 
-    impl<'a> Modifier<Response<'a>> for StatusCode {
-        fn modify(self, res: &mut Response<'a>) {
+    impl<'a, D> Modifier<Response<'a, D>> for StatusCode {
+        fn modify(self, res: &mut Response<'a, D>) {
             *res.status_mut() = self
         }
     }
 
-    impl<'a> Modifier<Response<'a>> for MediaType {
-        fn modify(self, res: &mut Response<'a>) {
+    impl<'a, D> Modifier<Response<'a, D>> for MediaType {
+        fn modify(self, res: &mut Response<'a, D>) {
             ContentType(self.into()).modify(res)
         }
     }
@@ -326,8 +335,8 @@ mod modifier_impls {
     macro_rules! header_modifiers {
         ($($t:ty),+) => (
             $(
-                impl<'a> Modifier<Response<'a>> for $t {
-                    fn modify(self, res: &mut Response<'a>) {
+                impl<'a, D> Modifier<Response<'a, D>> for $t {
+                    fn modify(self, res: &mut Response<'a, D>) {
                         res.headers_mut().set(self)
                     }
                 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,3 +1,4 @@
+use std::mem;
 use std::borrow::Cow;
 use std::sync::RwLock;
 use std::collections::HashMap;
@@ -19,6 +20,8 @@ use std::fs::File;
 use std::any::Any;
 use {NickelError, Halt, MiddlewareResult, Responder};
 use modifier::Modifier;
+use plugin::{Extensible, Pluggable};
+use typemap::TypeMap;
 
 pub type TemplateCache = RwLock<HashMap<String, Template>>;
 
@@ -28,6 +31,9 @@ pub struct Response<'a, D: 'a, T: 'static + Any = Fresh> {
     origin: HyperResponse<'a, T>,
     templates: &'a TemplateCache,
     data: &'a D,
+    map: TypeMap,
+    // This should be FnBox, but that's currently unstable
+    on_send: Vec<Box<FnMut(&mut Response<'a, D, Fresh>)>>
 }
 
 impl<'a, D> Response<'a, D, Fresh> {
@@ -38,7 +44,9 @@ impl<'a, D> Response<'a, D, Fresh> {
         Response {
             origin: response,
             templates: templates,
-            data: data
+            data: data,
+            map: TypeMap::new(),
+            on_send: vec![]
         }
     }
 
@@ -239,15 +247,25 @@ impl<'a, D> Response<'a, D, Fresh> {
     }
 
     pub fn start(mut self) -> Result<Response<'a, D, Streaming>, NickelError<'a, D>> {
+        let on_send = mem::replace(&mut self.on_send, vec![]);
+        for mut f in on_send.into_iter() {
+            // TODO: Ensure `f` doesn't call on_send again
+            f(&mut self)
+        }
+
+        // Set fallback headers last after everything runs, if we did this before as an
+        // on_send then it would possibly set redundant things.
         self.set_fallback_headers();
 
-        let Response { origin, templates, data } = self;
+        let Response { origin, templates, data, map, on_send } = self;
         match origin.start() {
             Ok(origin) => {
                 Ok(Response {
                     origin: origin,
                     templates: templates,
-                    data: data
+                    data: data,
+                    map: map,
+                    on_send: on_send
                 })
             },
             Err(e) =>
@@ -255,6 +273,11 @@ impl<'a, D> Response<'a, D, Fresh> {
                     Err(NickelError::without_response(format!("Failed to start response: {}", e)))
                 }
         }
+    }
+
+    pub fn on_send<F>(&mut self, f: F)
+            where F: FnMut(&mut Response<'a, D, Fresh>) + 'static {
+        self.on_send.push(Box::new(f))
     }
 }
 
@@ -297,7 +320,23 @@ impl <'a, D, T: 'static + Any> Response<'a, D, T> {
     pub fn headers(&self) -> &Headers {
         self.origin.headers()
     }
+
+    pub fn data(&self) -> &D {
+        &self.data
+    }
 }
+
+impl<'a, D, T: 'static + Any> Extensible for Response<'a, D, T> {
+    fn extensions(&self) -> &TypeMap {
+        &self.map
+    }
+
+    fn extensions_mut(&mut self) -> &mut TypeMap {
+        &mut self.map
+    }
+}
+
+impl<'a, D, T: 'static + Any> Pluggable for Response<'a, D, T> {}
 
 fn mime_from_filename<P: AsRef<Path>>(path: P) -> Option<MediaType> {
     path.as_ref()

--- a/src/router/http_router.rs
+++ b/src/router/http_router.rs
@@ -2,7 +2,7 @@ use hyper::method::Method;
 use middleware::Middleware;
 use router::Matcher;
 
-pub trait HttpRouter {
+pub trait HttpRouter<D> {
     /// Registers a handler to be used for a specified method.
     /// A handler can be anything implementing the `RequestHandler` trait.
     ///
@@ -36,7 +36,7 @@ pub trait HttpRouter {
     ///     server.add_route(Get, regex, middleware! { "Regex Get request! "});
     /// }
     /// ```
-    fn add_route<M: Into<Matcher>, H: Middleware>(&mut self, Method, M, H);
+    fn add_route<M: Into<Matcher>, H: Middleware<D>>(&mut self, Method, M, H);
 
     /// Registers a handler to be used for a specific GET request.
     /// Handlers are assigned to paths and paths are allowed to contain
@@ -106,42 +106,42 @@ pub trait HttpRouter {
     ///     server.utilize(router);
     /// }
     /// ```
-    fn get<M: Into<Matcher>, H: Middleware>(&mut self, matcher: M, handler: H) {
+    fn get<M: Into<Matcher>, H: Middleware<D>>(&mut self, matcher: M, handler: H) {
         self.add_route(Method::Get, matcher, handler);
     }
 
     /// Registers a handler to be used for a specific POST request.
     ///
     /// Take a look at `get(...)` for a more detailed description.
-    fn post<M: Into<Matcher>, H: Middleware>(&mut self, matcher: M, handler: H) {
+    fn post<M: Into<Matcher>, H: Middleware<D>>(&mut self, matcher: M, handler: H) {
         self.add_route(Method::Post, matcher, handler);
     }
 
     /// Registers a handler to be used for a specific PUT request.
     ///
     /// Take a look at `get(...)` for a more detailed description.
-    fn put<M: Into<Matcher>, H: Middleware>(&mut self, matcher: M, handler: H) {
+    fn put<M: Into<Matcher>, H: Middleware<D>>(&mut self, matcher: M, handler: H) {
         self.add_route(Method::Put, matcher, handler);
     }
 
     /// Registers a handler to be used for a specific DELETE request.
     ///
     /// Take a look at `get(...)` for a more detailed description.
-    fn delete<M: Into<Matcher>, H: Middleware>(&mut self, matcher: M, handler: H) {
+    fn delete<M: Into<Matcher>, H: Middleware<D>>(&mut self, matcher: M, handler: H) {
         self.add_route(Method::Delete, matcher, handler);
     }
 
     /// Registers a handler to be used for a specific OPTIONS request.
     ///
     /// Take a look at `get(...)` for a more detailed description.
-    fn options<M: Into<Matcher>, H: Middleware>(&mut self, matcher: M, handler: H) {
+    fn options<M: Into<Matcher>, H: Middleware<D>>(&mut self, matcher: M, handler: H) {
         self.add_route(Method::Options, matcher, handler);
     }
 
     /// Registers a handler to be used for a specific PATCH request.
     ///
     /// Take a look at `get(...)` for a more detailed description.
-    fn patch<M: Into<Matcher>, H: Middleware>(&mut self, matcher: M, handler: H) {
+    fn patch<M: Into<Matcher>, H: Middleware<D>>(&mut self, matcher: M, handler: H) {
         self.add_route(Method::Patch, matcher, handler);
     }
 }

--- a/src/router/router.rs
+++ b/src/router/router.rs
@@ -10,9 +10,9 @@ use router::{Matcher, FORMAT_PARAM};
 /// A Route is the basic data structure that stores both the path
 /// and the handler that gets executed for the route.
 /// The path can contain variable pattern such as `user/:userid/invoices`
-pub struct Route {
+pub struct Route<D=()> {
     pub method: Method,
-    pub handler: Box<Middleware + Send + Sync + 'static>,
+    pub handler: Box<Middleware<D> + Send + Sync + 'static>,
     matcher: Matcher
 }
 
@@ -20,12 +20,12 @@ pub struct Route {
 /// It contains the matched `route` and also a `params` property holding
 /// a HashMap with the keys being the variable names and the value being the
 /// evaluated string
-pub struct RouteResult<'a> {
-    pub route: &'a Route,
+pub struct RouteResult<'a, D: 'a> {
+    pub route: &'a Route<D>,
     params: Vec<(String, String)>
 }
 
-impl<'a> RouteResult<'a> {
+impl<'a, D> RouteResult<'a, D> {
     pub fn param(&self, key: &str) -> &str {
         for &(ref k, ref v) in &self.params {
             if k == &key {
@@ -42,18 +42,18 @@ impl<'a> RouteResult<'a> {
 /// The Router's job is it to hold routes and to resolve them later against
 /// concrete URLs. The router is also a regular middleware and needs to be
 /// added to the middleware stack with `server.utilize(router)`.
-pub struct Router {
-    routes: Vec<Route>,
+pub struct Router<D=()> {
+    routes: Vec<Route<D>>,
 }
 
-impl Router {
-    pub fn new () -> Router {
+impl<D=()> Router<D> {
+    pub fn new() -> Router<D> {
         Router {
             routes: Vec::new()
         }
     }
 
-    pub fn match_route<'a>(&'a self, method: &Method, path: &str) -> Option<RouteResult<'a>> {
+    pub fn match_route<'a>(&'a self, method: &Method, path: &str) -> Option<RouteResult<'a, D>> {
         self.routes
             .iter()
             .find(|item| item.method == *method && item.matcher.is_match(path))
@@ -66,7 +66,7 @@ impl Router {
     }
 }
 
-fn extract_params(route: &Route, path: &str) -> Vec<(String, String)> {
+fn extract_params<D>(route: &Route<D>, path: &str) -> Vec<(String, String)> {
     match route.matcher.captures(path) {
         Some(captures) => {
             captures.iter_named()
@@ -79,8 +79,8 @@ fn extract_params(route: &Route, path: &str) -> Vec<(String, String)> {
     }
 }
 
-impl HttpRouter for Router {
-    fn add_route<M: Into<Matcher>, H: Middleware>(&mut self, method: Method, matcher: M, handler: H) {
+impl<D> HttpRouter<D> for Router<D> {
+    fn add_route<M: Into<Matcher>, H: Middleware<D>>(&mut self, method: Method, matcher: M, handler: H) {
         let route = Route {
             matcher: matcher.into(),
             method: method,
@@ -91,9 +91,9 @@ impl HttpRouter for Router {
     }
 }
 
-impl Middleware for Router {
-    fn invoke<'a, 'b>(&'a self, req: &mut Request<'b, 'a, 'b>, mut res: Response<'a>)
-                        -> MiddlewareResult<'a> {
+impl<D: 'static> Middleware<D> for Router<D> {
+    fn invoke<'a, 'b>(&'a self, req: &mut Request<'b, 'a, 'b, D>, mut res: Response<'a, D>)
+                        -> MiddlewareResult<'a, D> {
         debug!("Router::invoke for '{:?}'", req.origin.uri);
 
         // Strip off the querystring when matching a route
@@ -187,7 +187,7 @@ fn creates_valid_regex_for_routes () {
 
 #[test]
 fn can_match_var_routes () {
-    let route_store = &mut Router::new();
+    let route_store = &mut Router::<()>::new();
 
     route_store.add_route(Method::Get, "/foo/:userid", middleware! { "hello from foo" });
     route_store.add_route(Method::Get, "/bar", middleware! { "hello from foo" });
@@ -252,7 +252,7 @@ fn can_match_var_routes () {
 
 #[test]
 fn params_lifetime() {
-    let route_store = &mut Router::new();
+    let route_store = &mut Router::<()>::new();
     let handler = middleware! { "hello from foo" };
 
     route_store.add_route(Method::Get, "/file/:format/:file", handler);
@@ -272,7 +272,7 @@ fn params_lifetime() {
 fn regex_path() {
     use regex::Regex;
 
-    let route_store = &mut Router::new();
+    let route_store = &mut Router::<()>::new();
 
     let regex = Regex::new("/(foo|bar)").unwrap();
     route_store.add_route(Method::Get, regex, middleware! { "hello from foo" });
@@ -294,7 +294,7 @@ fn regex_path() {
 fn regex_path_named() {
     use regex::Regex;
 
-    let route_store = &mut Router::new();
+    let route_store = &mut Router::<()>::new();
 
     let regex = Regex::new("/(?P<a>foo|bar)/b").unwrap();
     route_store.add_route(Method::Get, regex, middleware! { "hello from foo" });
@@ -319,7 +319,7 @@ fn regex_path_named() {
 fn ignores_querystring() {
     use regex::Regex;
 
-    let route_store = &mut Router::new();
+    let route_store = &mut Router::<()>::new();
 
     let regex = Regex::new("/(?P<a>foo|bar)/b").unwrap();
     route_store.add_route(Method::Get, regex, middleware! { "hello from foo" });

--- a/src/server.rs
+++ b/src/server.rs
@@ -9,32 +9,38 @@ use middleware::MiddlewareStack;
 use request;
 use response;
 
-pub struct Server {
-    middleware_stack: MiddlewareStack,
-    templates: response::TemplateCache
+pub struct Server<D> {
+    middleware_stack: MiddlewareStack<D>,
+    templates: response::TemplateCache,
+    shared_data: D,
 }
 
 // FIXME: Any better coherence solutions?
-struct ArcServer(Arc<Server>);
+struct ArcServer<D>(Arc<Server<D>>);
 
-impl Handler for ArcServer {
+impl<D: Sync + Send + 'static> Handler for ArcServer<D> {
     fn handle<'a, 'k>(&'a self, req: Request<'a, 'k>, res: Response<'a>) {
-        let nickel_req = request::Request::from_internal(req);
-        let nickel_res = response::Response::from_internal(res, &self.0.templates);
+        let nickel_req = request::Request::from_internal(req,
+                                                         &self.0.shared_data);
+
+        let nickel_res = response::Response::from_internal(res,
+                                                           &self.0.templates,
+                                                           &self.0.shared_data);
 
         self.0.middleware_stack.invoke(nickel_req, nickel_res);
     }
 }
 
-impl Server {
-    pub fn new(middleware_stack: MiddlewareStack) -> Server {
+impl<D: Sync + Send + 'static> Server<D> {
+    pub fn new(middleware_stack: MiddlewareStack<D>, data: D) -> Server<D> {
         Server {
             middleware_stack: middleware_stack,
-            templates: RwLock::new(HashMap::new())
+            templates: RwLock::new(HashMap::new()),
+            shared_data: data
         }
     }
 
-    pub fn serve<T: ToSocketAddrs>(self, addr: T) -> HttpResult<Listening> {
+    pub fn serve<A: ToSocketAddrs>(self, addr: A) -> HttpResult<Listening> {
         let arc = ArcServer(Arc::new(self));
         let server = HyperServer::http(arc);
         server.listen(addr)

--- a/tests/compile-fail/inference_fully_hinted.rs
+++ b/tests/compile-fail/inference_fully_hinted.rs
@@ -8,11 +8,11 @@ use nickel::{Nickel, HttpRouter, Request, Response};
 fn main() {
     let mut server = Nickel::new();
 
-    server.utilize(|_: &mut Request, res: Response| res.send("Hello World!"));
-    //~^ ERROR type mismatch resolving `for<'r,'b,'a> <[closure tests/com
+    server.utilize(|_: &mut Request<()>, res: Response<()>| res.send("Hello World!"));
+    //~^ ERROR type mismatch resolving `for<'r, 'b, 'a> <[closure tests/com
 
-    server.get("**", |_: &mut Request, res: Response| res.send("Hello World!"));
-    //~^ ERROR type mismatch resolving `for<'r,'b,'a> <[closure tests/com
+    server.get("**", |_: &mut Request<()>, res: Response<()>| res.send("Hello World!"));
+    //~^ ERROR type mismatch resolving `for<'r, 'b, 'a> <[closure tests/com
 
     server.listen("127.0.0.1:6767");
 }

--- a/tests/compile-fail/inference_no_hints.rs
+++ b/tests/compile-fail/inference_no_hints.rs
@@ -9,12 +9,12 @@ fn main() {
     let mut server = Nickel::new();
 
     server.utilize(|_, res| res.send("Hello World!"));
-    //~^ ERROR type mismatch resolving `for<'r,'b,'a> <[closure tests/compile-fail
+    //~^ ERROR type mismatch resolving `for<'r, 'b, 'a> <[closure tests/compile-fail
     //~^^ ERROR the type of this value must be known in this context
     //~^^^ ERROR type mismatch: the type `[closure tests/compile
 
     server.get("**", |_, res| res.send("Hello World!"));
-    //~^ ERROR type mismatch resolving `for<'r,'b,'a> <[closure tests/compile-fail
+    //~^ ERROR type mismatch resolving `for<'r, 'b, 'a> <[closure tests/compile-fail
     //~^^ ERROR the type of this value must be known in this context
     //~^^^ ERROR type mismatch: the type `[closure tests/compile
 

--- a/tests/compile-fail/inference_request_hinted.rs
+++ b/tests/compile-fail/inference_request_hinted.rs
@@ -9,13 +9,13 @@ fn main() {
     let mut server = Nickel::new();
 
     // Request hinted
-    server.utilize(|_: &mut Request, res| res.send("Hello World!"));
+    server.utilize(|_: &mut Request<()>, res| res.send("Hello World!"));
     //~^ ERROR the type of this value must be known in this context
-    //~^^ ERROR type mismatch resolving `for<'r,'b,'a>
+    //~^^ ERROR type mismatch resolving `for<'r, 'b, 'a>
 
-    server.get("**", |_: &mut Request, res| res.send("Hello World!"));
+    server.get("**", |_: &mut Request<()>, res| res.send("Hello World!"));
     //~^ ERROR the type of this value must be known in this context
-    //~^^ ERROR type mismatch resolving `for<'r,'b,'a>
+    //~^^ ERROR type mismatch resolving `for<'r, 'b, 'a>
 
     server.listen("127.0.0.1:6767");
 }

--- a/tests/compile-fail/inference_response_hinted.rs
+++ b/tests/compile-fail/inference_response_hinted.rs
@@ -8,12 +8,12 @@ use nickel::{Nickel, HttpRouter, Request, Response};
 fn main() {
     let mut server = Nickel::new();
 
-    server.utilize(|_, res: Response| res.send("Hello World!"));
-    //~^ ERROR type mismatch resolving `for<'r,'b,'a> <[closure tests/compile-fail
+    server.utilize(|_, res: Response<()>| res.send("Hello World!"));
+    //~^ ERROR type mismatch resolving `for<'r, 'b, 'a> <[closure tests/compile-fail
     //~^^ ERROR type mismatch: the type `[closure tests/compile-fail
 
-    server.get("**", |_, res: Response| res.send("Hello World!"));
-    //~^ ERROR type mismatch resolving `for<'r,'b,'a> <[closure tests/compile-fail
+    server.get("**", |_, res: Response<()>| res.send("Hello World!"));
+    //~^ ERROR type mismatch resolving `for<'r, 'b, 'a> <[closure tests/compile-fail
     //~^^ ERROR type mismatch: the type `[closure tests/compile-fail
 
     server.listen("127.0.0.1:6767");

--- a/tests/compile-fail/unmet_data_requirement.rs
+++ b/tests/compile-fail/unmet_data_requirement.rs
@@ -1,0 +1,41 @@
+#[macro_use] extern crate nickel;
+extern crate cookie;
+
+use nickel::{Nickel, HttpRouter, Cookies, QueryString};
+use nickel::cookies;
+use cookie::Cookie;
+
+struct Data {
+    secret_key: cookies::SecretKey
+}
+
+fn main() {
+    let data = Data { secret_key: cookies::SecretKey([0; 32]) };
+    let mut server = Nickel::with_data(data);
+
+    // Try curl -b MyCookie=bar localhost:6767
+    server.get("/", middleware! { |req|
+        let cookie = req.cookies().find("MyCookie");
+        //~^ ERROR: the trait `core::convert::AsRef<nickel::cookies::SecretKey>` is not implemented for the type `Data`
+        format!("MyCookie={:?}", cookie.map(|c| c.value))
+    });
+
+    // Note: Don't use get for login in real applications ;)
+    // Try http://localhost:6767/login?name=foo
+    server.get("/login", middleware! { |req, mut res|
+        let jar = res.cookies_mut()
+        //~^ ERROR: the trait `core::convert::AsRef<nickel::cookies::SecretKey>` is not implemented for the type `Data`
+                     // long life cookies!
+                     .permanent();
+
+        let name = req.query().get("name")
+                              .unwrap_or("default_name");
+        let cookie = Cookie::new("MyCookie".to_owned(),
+                                 name.to_owned());
+        jar.add(cookie);
+
+        "Cookie set!"
+    });
+
+    server.listen("127.0.0.1:6767");
+}


### PR DESCRIPTION
cc @SimonPersson 

This took a bit more thinking than I'd anticipated, but it required something similar to solving #79 for some configuration without incurring ordering dependencies (which could be potentially insecure for signed cookies) that seems slightly obvious in hindsight (and is very similar to something you suggested there). Still feels a bit iffy though, but I think it's sound enough to be useful.

The last commit does a bit of weirdness with where clauses on `Self` to collapse the `Cookies` trait into a single trait, but I think it's a lot nicer for users to only have to worry about importing a single trait.

cc #234 (original cookies implementation)