### PR TITLE
Remove 1.0 build target from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
 
 rust:
   - stable
-  - 1.0.0
   - nightly
   - beta
 

--- a/contributing.md
+++ b/contributing.md
@@ -2,7 +2,7 @@
 
 ## Before you begin
 
-Make sure to follow this [commit message convention](https://github.com/ajoslin/conventional-changelog/blob/master/CONVENTIONS.md) because we will auto generate a changelog with [clog](https://github.com/thoughtram/clog) in the future.
+Make sure to follow this [commit message convention](https://github.com/ajoslin/conventional-changelog/blob/master/conventions/angular.md) because we will auto generate a changelog with [clog](https://github.com/thoughtram/clog) in the future.
 
 # Getting started
 


### PR DESCRIPTION
hyper is tracking stable, so to keep things simple as rust develops, we should focus on the stable release channel as our moving target.

@cburgdorf @SimonPersson any hesitation?