### PR TITLE
feat(response): allow templates without data

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -184,6 +184,23 @@ impl<'a> Response<'a, Fresh> {
         if !headers.has::<H>() { headers.set(f()) }
     }
 
+
+    /// Renders the given template
+    ///
+    /// # Examples
+    /// ```{rust}
+    /// use std::collections::HashMap;
+    /// use nickel::{Request, Response, MiddlewareResult, Halt};
+    ///
+    /// fn handler<'a>(_: &mut Request, mut res: Response<'a>) -> MiddlewareResult<'a> {
+    ///     res.render("examples/assets/template.tpl")
+    /// }
+    /// ```
+    pub fn render_without_data<T, P>(self, path: P) -> MiddlewareResult<'a>
+            where P: AsRef<str> + Into<String> {
+        self.render(path, &())
+    }
+
     /// Renders the given template bound with the given data.
     ///
     /// # Examples


### PR DESCRIPTION
This improves ergonomics for template handling for when you don't want to pass data to the template. It's implementation relies on the already available `render` method (which I renamed to `render_with_data`) and just passes `&()`.

/cc @Ryman @SimonPersson 