### PR TITLE
Fix region errors uncovered by rust-lang/rust#27641

### DIFF
--- a/src/favicon_handler.rs
+++ b/src/favicon_handler.rs
@@ -19,7 +19,7 @@ pub struct FaviconHandler {
 }
 
 impl Middleware for FaviconHandler {
-    fn invoke<'a, 'b>(&'a self, req: &mut Request<'b, 'a, 'b>, res: Response<'a, net::Fresh>)
+    fn invoke<'a, 'b>(&'a self, req: &mut Request<'a, 'a, 'b>, res: Response<'a, net::Fresh>)
             -> MiddlewareResult<'a> {
         if FaviconHandler::is_favicon_request(req) {
             self.handle_request(req, res)

--- a/src/favicon_handler.rs
+++ b/src/favicon_handler.rs
@@ -19,7 +19,7 @@ pub struct FaviconHandler {
 }
 
 impl Middleware for FaviconHandler {
-    fn invoke<'a, 'b>(&'a self, req: &mut Request<'a, 'a, 'b>, res: Response<'a, net::Fresh>)
+    fn invoke<'a, 'server>(&'a self, req: &mut Request<'a, 'server>, res: Response<'a, net::Fresh>)
             -> MiddlewareResult<'a> {
         if FaviconHandler::is_favicon_request(req) {
             self.handle_request(req, res)
@@ -78,7 +78,7 @@ impl FaviconHandler {
         }
     }
 
-    pub fn send_favicon<'a, 'b>(&self, req: &Request, mut res: Response<'a>) -> MiddlewareResult<'a> {
+    pub fn send_favicon<'a, 'server>(&self, req: &Request, mut res: Response<'a>) -> MiddlewareResult<'a> {
         debug!("{:?} {:?}", req.origin.method, self.icon_path.display());
         res.set(MediaType::Ico);
         res.send(&*self.icon)

--- a/src/json_body_parser.rs
+++ b/src/json_body_parser.rs
@@ -8,7 +8,7 @@ use std::io::{Read, ErrorKind};
 // Plugin boilerplate
 struct JsonBodyParser;
 impl Key for JsonBodyParser { type Value = String; }
-impl<'a, 'b, 'k> Plugin<Request<'a, 'b, 'k>> for JsonBodyParser {
+impl<'mw, 'conn> Plugin<Request<'mw, 'conn>> for JsonBodyParser {
     type Error = io::Error;
 
     fn eval(req: &mut Request) -> Result<String, io::Error> {
@@ -22,7 +22,7 @@ pub trait JsonBody {
     fn json_as<T: Decodable>(&mut self) -> Result<T, io::Error>;
 }
 
-impl<'a, 'b, 'k> JsonBody for Request<'a, 'b, 'k> {
+impl<'mw, 'conn> JsonBody for Request<'mw, 'conn> {
     fn json_as<T: Decodable>(&mut self) -> Result<T, io::Error> {
         self.get_ref::<JsonBodyParser>().and_then(|parsed|
             json::decode::<T>(&*parsed).map_err(|err|

--- a/src/macros/middleware.rs
+++ b/src/macros/middleware.rs
@@ -38,8 +38,8 @@ macro_rules! _middleware_inner {
         use $crate::{MiddlewareResult,Responder, Response, Request};
 
         #[inline(always)]
-        fn restrict<'a, R: Responder>(r: R, res: Response<'a>)
-                -> MiddlewareResult<'a> {
+        fn restrict<'mw, R: Responder>(r: R, res: Response<'mw>)
+                -> MiddlewareResult<'mw> {
             res.send(r)
         }
 
@@ -47,9 +47,9 @@ macro_rules! _middleware_inner {
         // different mutability requirements
         #[inline(always)]
         fn restrict_closure<F>(f: F) -> F
-            where F: for<'r, 'b, 'a>
-                        Fn(&'r mut Request<'a, 'a, 'b>, Response<'a>)
-                            -> MiddlewareResult<'a> + Send + Sync { f }
+            where F: for<'r, 'mw, 'conn>
+                        Fn(&'r mut Request<'mw, 'conn>, Response<'mw>)
+                            -> MiddlewareResult<'mw> + Send + Sync { f }
 
         restrict_closure(move |as_pat!($req), $res_binding| {
             restrict(as_block!({$($b)+}), $res)

--- a/src/macros/middleware.rs
+++ b/src/macros/middleware.rs
@@ -48,7 +48,7 @@ macro_rules! _middleware_inner {
         #[inline(always)]
         fn restrict_closure<F>(f: F) -> F
             where F: for<'r, 'b, 'a>
-                        Fn(&'r mut Request<'b, 'a, 'b>, Response<'a>)
+                        Fn(&'r mut Request<'a, 'a, 'b>, Response<'a>)
                             -> MiddlewareResult<'a> + Send + Sync { f }
 
         restrict_closure(move |as_pat!($req), $res_binding| {

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -17,13 +17,13 @@ pub enum Action<T=(), U=()> {
 // the usage of + Send is weird here because what we really want is + Static
 // but that's not possible as of today. We have to use + Send for now.
 pub trait Middleware: Send + 'static + Sync {
-    fn invoke<'a, 'b>(&'a self, _req: &mut Request<'b, 'a, 'b>, res: Response<'a, net::Fresh>) -> MiddlewareResult<'a> {
+    fn invoke<'a, 'b>(&'a self, _req: &mut Request<'a, 'a, 'b>, res: Response<'a, net::Fresh>) -> MiddlewareResult<'a> {
         Ok(Continue(res))
     }
 }
 
-impl<T> Middleware for T where T: for<'r, 'b, 'a> Fn(&'r mut Request<'b, 'a, 'b>, Response<'a>) -> MiddlewareResult<'a> + Send + Sync + 'static {
-    fn invoke<'a, 'b>(&'a self, req: &mut Request<'b, 'a, 'b>, res: Response<'a>) -> MiddlewareResult<'a> {
+impl<T> Middleware for T where T: for<'r, 'b, 'a> Fn(&'r mut Request<'a, 'a, 'b>, Response<'a>) -> MiddlewareResult<'a> + Send + Sync + 'static {
+    fn invoke<'a, 'b>(&'a self, req: &mut Request<'a, 'a, 'b>, res: Response<'a>) -> MiddlewareResult<'a> {
         (*self)(req, res)
     }
 }

--- a/src/query_string.rs
+++ b/src/query_string.rs
@@ -33,7 +33,7 @@ impl Query {
 struct QueryStringParser;
 impl Key for QueryStringParser { type Value = Query; }
 
-impl<'a, 'b, 'k> Plugin<Request<'a, 'b, 'k>> for QueryStringParser {
+impl<'mw, 'conn> Plugin<Request<'mw, 'conn>> for QueryStringParser {
     type Error = ();
 
     fn eval(req: &mut Request) -> Result<Query, ()> {
@@ -46,7 +46,7 @@ pub trait QueryString {
     fn query(&mut self) -> &Query;
 }
 
-impl<'a, 'b, 'k> QueryString for Request<'a, 'b, 'k> {
+impl<'mw, 'conn> QueryString for Request<'mw, 'conn> {
     fn query(&mut self) -> &Query {
         self.get_ref::<QueryStringParser>()
             .ok()

--- a/src/request.rs
+++ b/src/request.rs
@@ -4,18 +4,24 @@ use typemap::TypeMap;
 use hyper::server::Request as HyperRequest;
 use hyper::uri::RequestUri::AbsolutePath;
 
-///A container for all the request data
-pub struct Request<'a, 'b, 'k: 'a> {
+/// A container for all the request data.
+///
+/// The lifetime `'mw` represents the lifetime of various bits of
+/// middleware state within nickel. It can vary and get shorter.
+///
+/// The lifetime `'server` represents the lifetime of data internal to
+/// the server. It is fixed and longer than `'mw`.
+pub struct Request<'mw, 'server: 'mw> {
     ///the original `hyper::server::Request`
-    pub origin: HyperRequest<'a, 'k>,
+    pub origin: HyperRequest<'mw, 'server>,
     ///a `HashMap<String, String>` holding all params with names and values
-    pub route_result: Option<RouteResult<'b>>,
+    pub route_result: Option<RouteResult<'mw>>,
 
     map: TypeMap
 }
 
-impl<'a, 'b, 'k> Request<'a, 'b, 'k> {
-    pub fn from_internal(req: HyperRequest<'a, 'k>) -> Request<'a, 'b, 'k> {
+impl<'mw, 'server> Request<'mw, 'server> {
+    pub fn from_internal(req: HyperRequest<'mw, 'server>) -> Request<'mw, 'server> {
         Request {
             origin: req,
             route_result: None,
@@ -35,7 +41,7 @@ impl<'a, 'b, 'k> Request<'a, 'b, 'k> {
     }
 }
 
-impl<'a, 'b, 'k> Extensible for Request<'a, 'b, 'k> {
+impl<'mw, 'server> Extensible for Request<'mw, 'server> {
     fn extensions(&self) -> &TypeMap {
         &self.map
     }
@@ -45,4 +51,4 @@ impl<'a, 'b, 'k> Extensible for Request<'a, 'b, 'k> {
     }
 }
 
-impl<'a, 'b, 'k> Pluggable for Request<'a, 'b, 'k> {}
+impl<'mw, 'server> Pluggable for Request<'mw, 'server> {}

--- a/src/request.rs
+++ b/src/request.rs
@@ -5,7 +5,7 @@ use hyper::server::Request as HyperRequest;
 use hyper::uri::RequestUri::AbsolutePath;
 
 ///A container for all the request data
-pub struct Request<'a, 'b: 'k, 'k: 'a> {
+pub struct Request<'a, 'b, 'k: 'a> {
     ///the original `hyper::server::Request`
     pub origin: HyperRequest<'a, 'k>,
     ///a `HashMap<String, String>` holding all params with names and values

--- a/src/router/router.rs
+++ b/src/router/router.rs
@@ -20,12 +20,12 @@ pub struct Route {
 /// It contains the matched `route` and also a `params` property holding
 /// a HashMap with the keys being the variable names and the value being the
 /// evaluated string
-pub struct RouteResult<'a> {
-    pub route: &'a Route,
+pub struct RouteResult<'mw> {
+    pub route: &'mw Route,
     params: Vec<(String, String)>
 }
 
-impl<'a> RouteResult<'a> {
+impl<'mw> RouteResult<'mw> {
     pub fn param(&self, key: &str) -> Option<&str> {
         for &(ref k, ref v) in &self.params {
             if k == &key {
@@ -56,7 +56,7 @@ impl Router {
         }
     }
 
-    pub fn match_route<'a>(&'a self, method: &Method, path: &str) -> Option<RouteResult<'a>> {
+    pub fn match_route<'mw>(&'mw self, method: &Method, path: &str) -> Option<RouteResult<'mw>> {
         self.routes
             .iter()
             .find(|item| item.method == *method && item.matcher.is_match(path))
@@ -95,8 +95,8 @@ impl HttpRouter for Router {
 }
 
 impl Middleware for Router {
-    fn invoke<'a, 'b>(&'a self, req: &mut Request<'a, 'a, 'b>, mut res: Response<'a>)
-                        -> MiddlewareResult<'a> {
+    fn invoke<'mw, 'conn>(&'mw self, req: &mut Request<'mw, 'conn>, mut res: Response<'mw>)
+                          -> MiddlewareResult<'mw> {
         debug!("Router::invoke for '{:?}'", req.origin.uri);
 
         // Strip off the querystring when matching a route

--- a/src/router/router.rs
+++ b/src/router/router.rs
@@ -95,7 +95,7 @@ impl HttpRouter for Router {
 }
 
 impl Middleware for Router {
-    fn invoke<'a, 'b>(&'a self, req: &mut Request<'b, 'a, 'b>, mut res: Response<'a>)
+    fn invoke<'a, 'b>(&'a self, req: &mut Request<'a, 'a, 'b>, mut res: Response<'a>)
                         -> MiddlewareResult<'a> {
         debug!("Router::invoke for '{:?}'", req.origin.uri);
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -19,9 +19,9 @@ struct ArcServer(Arc<Server>);
 
 impl Handler for ArcServer {
     fn handle<'a, 'k>(&'a self, req: Request<'a, 'k>, res: Response<'a>) {
+        let req: Request<'a, 'k> = req;
         let nickel_req = request::Request::from_internal(req);
         let nickel_res = response::Response::from_internal(res, &self.0.templates);
-
         self.0.middleware_stack.invoke(nickel_req, nickel_res);
     }
 }


### PR DESCRIPTION
The fixes for RFC rust-lang/rfcs#1214 uncovered some problems with how nickel was using lifetimes. These two patches correct the usage so that it will build after rust-lang/rust#27641 lands. I also attempted to move away from short names like `'a` and `'k` and instead give names to meaningful lifetimes within the processing of a request. I'm not sure that I found the best names, though. 

From what I can see, the role of the lifetime parameters is as follows:

`'k` -- represents the internal hyper state, such as the network connection. I called this `'conn`.

`'a` and `'b` -- are both varying lifetimes that generally represent "the shortest lifetime of any borrowed data in the Request". Generally this is the lifetime of the "middleware" portion of request processing, so I called it `'mw`.

To put this another way, I think that when we are processing any particular request, the stack frames are layered roughly like so, with the lifetimes `'mw` and `'conn` labeled:

```
<hyper>                +---------+ 'conn
                                 |
<nickle>               +--+ 'mw  |
                          |      |
<middleware>              |      |
                          v      v
```