### PR TITLE
feat(response): add next_middleware method for convenience

### DIFF
--- a/examples/macro_example.rs
+++ b/examples/macro_example.rs
@@ -21,7 +21,7 @@ struct Person {
 //this is an example middleware function that just logs each request
 fn logger<'a, D>(request: &mut Request<D>, response: Response<'a, D>) -> MiddlewareResult<'a, D> {
     println!("logging request: {:?}", request.origin.uri);
-    Ok(Continue(response))
+    response.next_middleware()
 }
 
 //this is how to overwrite the default error handler to handle 404 cases with a custom view

--- a/src/favicon_handler.rs
+++ b/src/favicon_handler.rs
@@ -9,7 +9,7 @@ use hyper::header;
 
 use request::Request;
 use response::Response;
-use middleware::{Continue, Middleware, MiddlewareResult};
+use middleware::{Middleware, MiddlewareResult};
 use mimes::MediaType;
 
 pub struct FaviconHandler {
@@ -23,7 +23,7 @@ impl<D> Middleware<D> for FaviconHandler {
         if FaviconHandler::is_favicon_request(req) {
             self.handle_request(req, res)
         } else {
-            Ok(Continue(res))
+            res.next_middleware()
         }
     }
 }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -18,7 +18,7 @@ pub enum Action<T=(), U=()> {
 // but that's not possible as of today. We have to use + Send for now.
 pub trait Middleware<D>: Send + 'static + Sync {
     fn invoke<'mw, 'conn>(&'mw self, _req: &mut Request<'mw, 'conn, D>, res: Response<'mw, D, net::Fresh>) -> MiddlewareResult<'mw, D> {
-        Ok(Continue(res))
+        res.next_middleware()
     }
 }
 

--- a/src/responder.rs
+++ b/src/responder.rs
@@ -9,7 +9,7 @@
 //! in any request.
 //!
 //! Please see the examples for usage.
-use {Response, NickelError, MiddlewareResult, Halt, Continue};
+use {Response, NickelError, MiddlewareResult, Halt};
 use hyper::status::{StatusCode, StatusClass};
 use hyper::header;
 use serialize::json;
@@ -27,7 +27,7 @@ pub trait Responder<D> {
 
 impl<D> Responder<D> for () {
     fn respond<'a>(self, res: Response<'a, D>) -> MiddlewareResult<'a, D> {
-        Ok(Continue(res))
+        res.next_middleware()
     }
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -18,7 +18,7 @@ use mustache::Template;
 use std::io::{self, Read, Write, copy};
 use std::fs::File;
 use std::any::Any;
-use {NickelError, Halt, MiddlewareResult, Responder};
+use {NickelError, Halt, MiddlewareResult, Responder, Action};
 use modifier::Modifier;
 use plugin::{Extensible, Pluggable};
 use typemap::TypeMap;
@@ -286,6 +286,14 @@ impl<'a, D> Response<'a, D, Fresh> {
     pub fn on_send<F>(&mut self, f: F)
             where F: FnMut(&mut Response<'a, D, Fresh>) + 'static {
         self.on_send.push(Box::new(f))
+    }
+
+    /// Pass execution off to another Middleware
+    ///
+    /// When returned from a Middleware, it allows computation to continue
+    /// in any Middleware queued after the active one.
+    pub fn next_middleware(self) -> MiddlewareResult<'a, D> {
+        Ok(Action::Continue(self))
     }
 }
 

--- a/src/router/router.rs
+++ b/src/router/router.rs
@@ -1,4 +1,4 @@
-use middleware::{Middleware, Continue, MiddlewareResult};
+use middleware::{Middleware, MiddlewareResult};
 
 use request::Request;
 use response::Response;
@@ -113,7 +113,7 @@ impl<D: 'static> Middleware<D> for Router<D> {
                 req.route_result = Some(route_result);
                 handler.invoke(req, res)
             },
-            None => Ok(Continue(res))
+            None => res.next_middleware()
         }
     }
 }

--- a/src/static_files_handler.rs
+++ b/src/static_files_handler.rs
@@ -6,7 +6,7 @@ use hyper::method::Method::{Get, Head};
 
 use request::Request;
 use response::Response;
-use middleware::{Continue, Middleware, MiddlewareResult};
+use middleware::{Middleware, MiddlewareResult};
 
 // this should be much simpler after unboxed closures land in Rust.
 
@@ -20,7 +20,7 @@ impl<D> Middleware<D> for StaticFilesHandler {
             -> MiddlewareResult<'a, D> {
         match req.origin.method {
             Get | Head => self.with_file(self.extract_path(req), res),
-            _ => Ok(Continue(res))
+            _ => res.next_middleware()
         }
     }
 }
@@ -70,6 +70,6 @@ impl StaticFilesHandler {
             }
         };
 
-        Ok(Continue(res))
+        res.next_middleware()
     }
 }


### PR DESCRIPTION
This seems more intuitive, less imports, less types to know about, does what it says.