### PR TITLE
Another day, Another session.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ before_script:
 
 script:
   - |
-      travis-cargo build &&
-      travis-cargo test &&
-      travis-cargo doc &&
+      travis-cargo build $FEATURES &&
+      travis-cargo test $FEATURES &&
+      travis-cargo doc $FEATURES &&
       echo "Testing README" &&
       rustdoc --test README.md -L dependency=./target/debug/deps --extern nickel=./target/debug/libnickel.rlib
 
@@ -34,3 +34,10 @@ after_success:
 env:
   global:
     secure: nPXTdkq9TK4LmqJWqB4jxscDG1mnqJzO0UX5ni+oC0SohjgBxdWjbvJ8Kthk3c8Qg/2zGlCryuT1lV4TcD3jF86MHlRlXsO3G8fCbEGdLLzppbV0A2VnEw1knhv2mfUhxA8hsFJE2ncT5qeOVyQ6N3PAMGoYkdhhbD9N/9EWuqs=
+  matrix:
+    # travis-cargo requires prefixing additional args with --
+    - FEATURES=""
+    - FEATURES="-- --features ssl"
+    - FEATURES="-- --features session"
+    - FEATURES="-- --features secure_cookies"
+    - FEATURES="-- --no-default-features"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ keywords = ["nickel", "server", "web", "express"]
 [features]
 unstable = ["hyper/nightly", "compiletest_rs"]
 ssl = ["hyper/ssl"]
+secure_cookies = ["cookie/secure"]
+session = ["secure_cookies"]
 
 [dependencies]
 url = "*"
@@ -33,7 +35,7 @@ byteorder = "^0.3"
 rand = "^0.3"
 
 [dependencies.hyper]
-version = "=0.6"
+version = "^0.6"
 default-features = false
 
 [dependencies.compiletest_rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ mustache = "*"
 lazy_static = "*"
 modifier = "*"
 cookie = "^0.1"
+byteorder = "^0.3"
 
 [dependencies.hyper]
 version = "=0.6"
@@ -42,6 +43,11 @@ optional = true
 
 name = "example"
 path = "examples/example.rs"
+
+[[example]]
+
+name = "session_example"
+path = "examples/session_example.rs"
 
 [[example]]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ lazy_static = "*"
 modifier = "*"
 cookie = "^0.1"
 byteorder = "^0.3"
+rand = "^0.3"
 
 [dependencies.hyper]
 version = "=0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ groupable = "*"
 mustache = "*"
 lazy_static = "*"
 modifier = "*"
+cookie = "^0.1"
 
 [dependencies.hyper]
 version = "=0.6"
@@ -41,6 +42,11 @@ optional = true
 
 name = "example"
 path = "examples/example.rs"
+
+[[example]]
+
+name = "cookies_example"
+path = "examples/cookies_example.rs"
 
 [[example]]
 

--- a/examples/cookies_example.rs
+++ b/examples/cookies_example.rs
@@ -29,5 +29,31 @@ fn main() {
         "Cookie set!"
     });
 
+    // Try `curl -c /tmp/cookie -b /tmp/cookie http://localhost:6767/secure?value=foobar`
+    // when the `secure_cookies` feature is enabled
+    // i.e. `cargo run --example cookies_example --features secure_cookies
+    if cfg!(feature = "secure_cookies") {
+        server.get("/secure", middleware! { |req, mut res|
+            let jar = res.cookies_mut()
+                         .encrypted();
+
+            let new_value = req.query().get("value")
+                                   .unwrap_or("no value")
+                                   .to_owned();
+
+            let cookie = Cookie::new("SecureCookie".to_owned(),
+                                     new_value);
+            jar.add(cookie);
+
+            // Old value from the request's Cookies
+            let old_value = req.cookies()
+                               .encrypted()
+                               .find("SecureCookie")
+                               .map(|c| c.value);
+
+            format!("Old value was {:?}", old_value)
+        });
+    }
+
     server.listen("127.0.0.1:6767");
 }

--- a/examples/cookies_example.rs
+++ b/examples/cookies_example.rs
@@ -2,22 +2,10 @@
 extern crate cookie;
 
 use nickel::{Nickel, HttpRouter, Cookies, QueryString};
-use nickel::cookies;
 use cookie::Cookie;
 
-struct Data {
-    secret_key: cookies::SecretKey
-}
-
-impl cookies::KeyProvider for Data {
-    fn key(&self) -> cookies::SecretKey {
-        self.secret_key.clone()
-    }
-}
-
 fn main() {
-    let data = Data { secret_key: cookies::SecretKey([0; 32]) };
-    let mut server = Nickel::with_data(data);
+    let mut server = Nickel::new();
 
     // Try curl -b MyCookie=bar localhost:6767
     server.get("/", middleware! { |req|

--- a/examples/cookies_example.rs
+++ b/examples/cookies_example.rs
@@ -1,0 +1,28 @@
+#[macro_use] extern crate nickel;
+extern crate cookie;
+
+use nickel::{Nickel, HttpRouter, Cookies};
+use nickel::cookies;
+
+struct Data {
+    secret_key: cookies::SecretKey
+}
+
+impl AsRef<cookies::SecretKey> for Data {
+    fn as_ref(&self) -> &cookies::SecretKey {
+        &self.secret_key
+    }
+}
+
+fn main() {
+    let data = Data { secret_key: cookies::SecretKey([0; 32]) };
+    let mut server = Nickel::with_data(data);
+
+    // Try curl -b MyCookie=bar localhost:6767
+    server.get("/", middleware! { |req|
+        let cookie = req.cookies().find("MyCookie");
+        format!("MyCookie={:?}", cookie.map(|c| c.value))
+    });
+
+    server.listen("127.0.0.1:6767");
+}

--- a/examples/cookies_example.rs
+++ b/examples/cookies_example.rs
@@ -1,7 +1,7 @@
 #[macro_use] extern crate nickel;
 extern crate cookie;
 
-use nickel::{Nickel, HttpRouter, Cookies, CookiesMut, QueryString};
+use nickel::{Nickel, HttpRouter, Cookies, QueryString};
 use nickel::cookies;
 use cookie::Cookie;
 

--- a/examples/cookies_example.rs
+++ b/examples/cookies_example.rs
@@ -1,8 +1,9 @@
 #[macro_use] extern crate nickel;
 extern crate cookie;
 
-use nickel::{Nickel, HttpRouter, Cookies};
+use nickel::{Nickel, HttpRouter, Cookies, CookiesMut, QueryString};
 use nickel::cookies;
+use cookie::Cookie;
 
 struct Data {
     secret_key: cookies::SecretKey
@@ -22,6 +23,22 @@ fn main() {
     server.get("/", middleware! { |req|
         let cookie = req.cookies().find("MyCookie");
         format!("MyCookie={:?}", cookie.map(|c| c.value))
+    });
+
+    // Note: Don't use get for login in real applications ;)
+    // Try http://localhost:6767/login?name=foo
+    server.get("/login", middleware! { |req, mut res|
+        let jar = res.cookies_mut()
+                     // long life cookies!
+                     .permanent();
+
+        let name = req.query().get("name")
+                              .unwrap_or("default_name");
+        let cookie = Cookie::new("MyCookie".to_owned(),
+                                 name.to_owned());
+        jar.add(cookie);
+
+        "Cookie set!"
     });
 
     server.listen("127.0.0.1:6767");

--- a/examples/cookies_example.rs
+++ b/examples/cookies_example.rs
@@ -9,9 +9,9 @@ struct Data {
     secret_key: cookies::SecretKey
 }
 
-impl AsRef<cookies::SecretKey> for Data {
-    fn as_ref(&self) -> &cookies::SecretKey {
-        &self.secret_key
+impl cookies::KeyProvider for Data {
+    fn key(&self) -> cookies::SecretKey {
+        self.secret_key.clone()
     }
 }
 

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -113,7 +113,7 @@ fn main() {
     server.utilize(StaticFilesHandler::new("examples/assets/"));
 
     //this is how to overwrite the default error handler to handle 404 cases with a custom view
-    fn custom_404<'a>(err: &mut NickelError, _req: &mut Request) -> Action {
+    fn custom_404<'a, D>(err: &mut NickelError<D>, _req: &mut Request<D>) -> Action {
         if let Some(ref mut res) = err.stream {
             if res.status() == NotFound {
                 let _ = res.write_all(b"<h1>Call the police!</h1>");
@@ -126,7 +126,7 @@ fn main() {
 
 
     // issue #20178
-    let custom_handler: fn(&mut NickelError, &mut Request) -> Action = custom_404;
+    let custom_handler: fn(&mut NickelError<()>, &mut Request<()>) -> Action = custom_404;
 
     server.handle_error(custom_handler);
 

--- a/examples/macro_example.rs
+++ b/examples/macro_example.rs
@@ -19,13 +19,13 @@ struct Person {
 }
 
 //this is an example middleware function that just logs each request
-fn logger<'a>(request: &mut Request, response: Response<'a>) -> MiddlewareResult<'a> {
+fn logger<'a, D>(request: &mut Request<D>, response: Response<'a, D>) -> MiddlewareResult<'a, D> {
     println!("logging request: {:?}", request.origin.uri);
     Ok(Continue(response))
 }
 
 //this is how to overwrite the default error handler to handle 404 cases with a custom view
-fn custom_404<'a>(err: &mut NickelError, _req: &mut Request) -> Action {
+fn custom_404<'a, D>(err: &mut NickelError<D>, _req: &mut Request<D>) -> Action {
     if let Some(ref mut res) = err.stream {
         if res.status() == NotFound {
             let _ = res.write_all(b"<h1>Call the police!</h1>");
@@ -122,7 +122,7 @@ fn main() {
     ));
 
     // issue #20178
-    let custom_handler: fn(&mut NickelError, &mut Request) -> Action = custom_404;
+    let custom_handler: fn(&mut NickelError<()>, &mut Request<()>) -> Action = custom_404;
 
     server.handle_error(custom_handler);
 

--- a/examples/session_example.rs
+++ b/examples/session_example.rs
@@ -16,8 +16,8 @@ struct User {
 struct ServerData;
 static SECRET_KEY: &'static cookies::SecretKey = &cookies::SecretKey([0; 32]);
 
-impl AsRef<cookies::SecretKey> for ServerData {
-    fn as_ref(&self) -> &cookies::SecretKey { SECRET_KEY }
+impl cookies::KeyProvider for ServerData {
+    fn key(&self) -> cookies::SecretKey { SECRET_KEY.clone() }
 }
 
 impl SessionStore for ServerData {

--- a/examples/session_example.rs
+++ b/examples/session_example.rs
@@ -1,0 +1,74 @@
+#[macro_use] extern crate nickel;
+extern crate rustc_serialize;
+extern crate time;
+
+use std::io::Write;
+use nickel::*;
+use nickel::status::StatusCode;
+use time::Duration;
+
+#[derive(RustcDecodable, RustcEncodable)]
+struct User {
+    name: String,
+    password:  String,
+}
+
+struct ServerData;
+static SECRET_KEY: &'static cookies::SecretKey = &cookies::SecretKey([0; 32]);
+
+impl AsRef<cookies::SecretKey> for ServerData {
+    fn as_ref(&self) -> &cookies::SecretKey { SECRET_KEY }
+}
+
+impl SessionStore for ServerData {
+    type Store = Option<String>;
+
+    fn timeout() -> Duration {
+        Duration::seconds(5)
+    }
+}
+
+
+fn main() {
+    let mut server = Nickel::with_data(ServerData);
+
+    // Anyone should be able to reach this route
+    server.get("/", middleware! { |req, mut res|
+        format!("You are logged in as: {:?}\n", CookieSession::get_mut(req, &mut res))
+    });
+
+    server.post("/login", middleware!{|req, mut res|
+        if let Ok(u) = req.json_as::<User>() {
+            if u.name == "foo" && u.password == "bar" {
+                *CookieSession::get_mut(req, &mut res) = Some(u.name);
+                return res.send("Successfully logged in.")
+            }
+        }
+        (StatusCode::BadRequest, "Access denied.")
+    });
+
+    server.get("/secret", middleware! { |req, mut res| <ServerData>
+        match *CookieSession::get_mut(req, &mut res) {
+            Some(ref user) if user == "foo" => (StatusCode::Ok, "Some hidden information!"),
+            _ => (StatusCode::Forbidden, "Access denied.")
+        }
+    });
+
+    fn custom_403<'a>(err: &mut NickelError<ServerData>, _: &mut Request<ServerData>) -> Action {
+        if let Some(ref mut res) = err.stream {
+            if res.status() == StatusCode::Forbidden {
+                let _ = res.write_all(b"Access denied!\n");
+                return Halt(())
+            }
+        }
+
+        Continue(())
+    }
+
+    // issue #20178
+    let custom_handler: fn(&mut NickelError<ServerData>, &mut Request<ServerData>) -> Action = custom_403;
+
+    server.handle_error(custom_handler);
+
+    server.listen("127.0.0.1:6767");
+}

--- a/examples/session_example.rs
+++ b/examples/session_example.rs
@@ -25,8 +25,8 @@ impl cookies::KeyProvider for ServerData {
 }
 
 #[cfg(feature = "session")]
-impl SessionStore for ServerData {
-    type Store = Option<String>;
+impl session::Store for ServerData {
+    type Session = Option<String>;
 
     fn timeout() -> Duration {
         Duration::seconds(5)

--- a/examples/session_example.rs
+++ b/examples/session_example.rs
@@ -1,3 +1,6 @@
+//! This example only works if you enable the `session` feature.
+#![cfg_attr(not(feature = "session"), allow(dead_code, unused_imports))]
+
 #[macro_use] extern crate nickel;
 extern crate rustc_serialize;
 extern crate time;
@@ -16,10 +19,12 @@ struct User {
 struct ServerData;
 static SECRET_KEY: &'static cookies::SecretKey = &cookies::SecretKey([0; 32]);
 
+#[cfg(feature = "session")]
 impl cookies::KeyProvider for ServerData {
     fn key(&self) -> cookies::SecretKey { SECRET_KEY.clone() }
 }
 
+#[cfg(feature = "session")]
 impl SessionStore for ServerData {
     type Store = Option<String>;
 
@@ -28,7 +33,10 @@ impl SessionStore for ServerData {
     }
 }
 
+#[cfg(not(feature = "session"))]
+fn main() {}
 
+#[cfg(feature = "session")]
 fn main() {
     let mut server = Nickel::with_data(ServerData);
 

--- a/src/cookies.rs
+++ b/src/cookies.rs
@@ -1,0 +1,38 @@
+use request::Request;
+use plugin::{Plugin, Pluggable};
+use typemap::Key;
+use hyper::header;
+
+use cookie::CookieJar;
+
+pub struct SecretKey(pub [u8; 32]);
+
+// Plugin boilerplate
+struct CookiePlugin;
+impl Key for CookiePlugin { type Value = CookieJar<'static>; }
+
+impl<'mw, 'conn, D> Plugin<Request<'mw, 'conn, D>> for CookiePlugin
+        where D: AsRef<SecretKey> {
+    type Error = ();
+
+    fn eval(req: &mut Request<D>) -> Result<CookieJar<'static>, ()> {
+        let key = req.data().as_ref();
+        let jar = match req.origin.headers.get::<header::Cookie>() {
+            Some(c) => c.to_cookie_jar(&key.0),
+            None => CookieJar::new(&key.0)
+        };
+
+        Ok(jar)
+    }
+}
+
+pub trait Cookies {
+    fn cookies(&mut self) -> &CookieJar;
+}
+
+impl<'mw, 'conn, D> Cookies for Request<'mw, 'conn, D>
+        where D: AsRef<SecretKey> {
+    fn cookies(&mut self) -> &CookieJar {
+        self.get_ref::<CookiePlugin>().unwrap()
+    }
+}

--- a/src/cookies.rs
+++ b/src/cookies.rs
@@ -1,4 +1,4 @@
-use request::Request;
+use {Request, Response};
 use plugin::{Plugin, Pluggable};
 use typemap::Key;
 use hyper::header;
@@ -34,5 +34,35 @@ impl<'mw, 'conn, D> Cookies for Request<'mw, 'conn, D>
         where D: AsRef<SecretKey> {
     fn cookies(&mut self) -> &CookieJar {
         self.get_ref::<CookiePlugin>().unwrap()
+    }
+}
+
+impl<'a, 'b, 'k, D> Plugin<Response<'a, D>> for CookiePlugin
+        where D: AsRef<SecretKey> {
+    type Error = ();
+
+    fn eval(res: &mut Response<'a, D>) -> Result<CookieJar<'static>, ()> {
+        // Schedule the cookie to be written when headers are being sent
+        res.on_send(|res| {
+            let header = {
+                let jar = res.get_ref::<CookiePlugin>().unwrap();
+                header::SetCookie::from_cookie_jar(jar)
+            };
+            res.set(header);
+        });
+
+        let key = res.data().as_ref();
+        Ok(CookieJar::new(&key.0))
+    }
+}
+
+pub trait CookiesMut {
+    fn cookies_mut(&mut self) -> &mut CookieJar<'static>;
+}
+
+impl<'a, D> CookiesMut for Response<'a, D>
+        where D: AsRef<SecretKey> {
+    fn cookies_mut(&mut self) -> &mut CookieJar<'static> {
+        self.get_mut::<CookiePlugin>().unwrap()
     }
 }

--- a/src/cookies.rs
+++ b/src/cookies.rs
@@ -1,5 +1,5 @@
 use {Request, Response};
-use plugin::{Plugin, Pluggable, Extensible};
+use plugin::{Plugin, Pluggable};
 use typemap::Key;
 use hyper::header;
 
@@ -8,7 +8,7 @@ use cookie::CookieJar;
 pub struct SecretKey(pub [u8; 32]);
 
 // Plugin boilerplate
-struct CookiePlugin;
+pub struct CookiePlugin;
 impl Key for CookiePlugin { type Value = CookieJar<'static>; }
 
 impl<'mw, 'conn, D> Plugin<Request<'mw, 'conn, D>> for CookiePlugin
@@ -60,21 +60,32 @@ impl<'a, D> AllowMutCookies for Response<'a, D> {}
 ///
 /// #Examples
 /// See `examples/cookies_example.rs`.
-pub trait Cookies : Pluggable + Extensible
-        where CookiePlugin: Plugin<Self, Value=CookieJar<'static>, Error=()> {
+pub trait Cookies {
     /// Provides access to an immutable CookieJar.
     ///
     /// Currently requires a mutable reciever, hopefully this can change in future.
-    fn cookies(&mut self) -> &CookieJar {
+    fn cookies(&mut self) -> &CookieJar<'static>;
+
+    /// Provides access to a mutable CookieJar.
+    fn cookies_mut(&mut self) -> &mut CookieJar<'static> where Self: AllowMutCookies;
+}
+
+impl<'mw, 'conn, D: AsRef<SecretKey>> Cookies for Request<'mw, 'conn, D> {
+    fn cookies(&mut self) -> &<CookiePlugin as Key>::Value {
         self.get_ref::<CookiePlugin>().unwrap()
     }
 
-    /// Provides access to a mutable CookieJar.
-    fn cookies_mut(&mut self) -> &mut CookieJar<'static> where Self: AllowMutCookies {
-        self.get_mut::<CookiePlugin>().unwrap()
+    fn cookies_mut(&mut self) -> &mut <CookiePlugin as Key>::Value where Self: AllowMutCookies {
+        unreachable!()
     }
 }
 
-impl<'mw, 'conn, D: AsRef<SecretKey>> Cookies for Request<'mw, 'conn, D> {}
+impl<'mw, D: AsRef<SecretKey>> Cookies for Response<'mw, D> {
+    fn cookies(&mut self) -> &<CookiePlugin as Key>::Value {
+        self.get_ref::<CookiePlugin>().unwrap()
+    }
 
-impl<'a, D: AsRef<SecretKey>> Cookies for Response<'a, D> {}
+    fn cookies_mut(&mut self) -> &mut <CookiePlugin as Key>::Value where Self: AllowMutCookies {
+        self.get_mut::<CookiePlugin>().unwrap()
+    }
+}

--- a/src/cookies.rs
+++ b/src/cookies.rs
@@ -73,6 +73,10 @@ impl<'a, D> AllowMutCookies for Response<'a, D> {}
 ///
 /// Implementors should aim to provide a stable key between server reboots so
 /// as to minimize data loss in client cookies.
+///
+/// # Implementing
+///
+/// The `secure_cookies` feature needs to be enabled for this to be implementable
 pub trait KeyProvider {
     fn key(&self) -> SecretKey {
         lazy_static! {
@@ -85,6 +89,16 @@ pub trait KeyProvider {
         };
 
         CACHED_SECRET.clone()
+    }
+}
+
+#[cfg(feature = "secure_cookies")]
+impl KeyProvider for () {}
+
+#[cfg(not(feature = "secure_cookies"))]
+impl<T> KeyProvider for T {
+    fn key(&self) -> SecretKey {
+        SecretKey([0; 32])
     }
 }
 

--- a/src/default_error_handler.rs
+++ b/src/default_error_handler.rs
@@ -7,8 +7,8 @@ use std::io::Write;
 #[derive(Clone, Copy)]
 pub struct DefaultErrorHandler;
 
-impl ErrorHandler for DefaultErrorHandler {
-    fn handle_error(&self, err: &mut NickelError, _req: &mut Request) -> Action {
+impl<D> ErrorHandler<D> for DefaultErrorHandler {
+    fn handle_error(&self, err: &mut NickelError<D>, _req: &mut Request<D>) -> Action {
         if let Some(ref mut res) = err.stream {
             let msg : &[u8] = match res.status() {
                 NotFound => b"Not Found",

--- a/src/favicon_handler.rs
+++ b/src/favicon_handler.rs
@@ -6,7 +6,6 @@ use hyper::uri::RequestUri::AbsolutePath;
 use hyper::method::Method::{Get, Head, Options};
 use hyper::status::StatusCode;
 use hyper::header;
-use hyper::net;
 
 use request::Request;
 use response::Response;
@@ -18,9 +17,9 @@ pub struct FaviconHandler {
     icon_path: PathBuf, // Is it useful to log where in-memory favicon came from every request?
 }
 
-impl Middleware for FaviconHandler {
-    fn invoke<'a, 'server>(&'a self, req: &mut Request<'a, 'server>, res: Response<'a, net::Fresh>)
-            -> MiddlewareResult<'a> {
+impl<D> Middleware<D> for FaviconHandler {
+    fn invoke<'a, 'server>(&'a self, req: &mut Request<'a, 'server, D>, res: Response<'a, D>)
+            -> MiddlewareResult<'a, D> {
         if FaviconHandler::is_favicon_request(req) {
             self.handle_request(req, res)
         } else {
@@ -53,14 +52,14 @@ impl FaviconHandler {
     }
 
     #[inline]
-    pub fn is_favicon_request(req: &Request) -> bool {
+    pub fn is_favicon_request<D>(req: &Request<D>) -> bool {
         match req.origin.uri {
             AbsolutePath(ref path) => &**path == "/favicon.ico",
             _                      => false
         }
     }
 
-    pub fn handle_request<'a>(&self, req: &Request, mut res: Response<'a>) -> MiddlewareResult<'a> {
+    pub fn handle_request<'a, D>(&self, req: &Request<D>, mut res: Response<'a, D>) -> MiddlewareResult<'a, D> {
         match req.origin.method {
             Get | Head => {
                 self.send_favicon(req, res)
@@ -78,7 +77,7 @@ impl FaviconHandler {
         }
     }
 
-    pub fn send_favicon<'a, 'server>(&self, req: &Request, mut res: Response<'a>) -> MiddlewareResult<'a> {
+    pub fn send_favicon<'a, D>(&self, req: &Request<D>, mut res: Response<'a, D>) -> MiddlewareResult<'a, D> {
         debug!("{:?} {:?}", req.origin.method, self.icon_path.display());
         res.set(MediaType::Ico);
         res.send(&*self.icon)

--- a/src/json_body_parser.rs
+++ b/src/json_body_parser.rs
@@ -8,10 +8,11 @@ use std::io::{Read, ErrorKind};
 // Plugin boilerplate
 struct JsonBodyParser;
 impl Key for JsonBodyParser { type Value = String; }
-impl<'mw, 'conn> Plugin<Request<'mw, 'conn>> for JsonBodyParser {
+
+impl<'mw, 'conn, D> Plugin<Request<'mw, 'conn, D>> for JsonBodyParser {
     type Error = io::Error;
 
-    fn eval(req: &mut Request) -> Result<String, io::Error> {
+    fn eval(req: &mut Request<D>) -> Result<String, io::Error> {
         let mut s = String::new();
         try!(req.origin.read_to_string(&mut s));
         Ok(s)
@@ -22,7 +23,7 @@ pub trait JsonBody {
     fn json_as<T: Decodable>(&mut self) -> Result<T, io::Error>;
 }
 
-impl<'mw, 'conn> JsonBody for Request<'mw, 'conn> {
+impl<'mw, 'conn, D> JsonBody for Request<'mw, 'conn, D> {
     fn json_as<T: Decodable>(&mut self) -> Result<T, io::Error> {
         self.get_ref::<JsonBodyParser>().and_then(|parsed|
             json::decode::<T>(&*parsed).map_err(|err|

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ pub use router::{Router, Route, RouteResult, HttpRouter};
 pub use nickel_error::NickelError;
 pub use mimes::MediaType;
 pub use responder::Responder;
-pub use cookies::Cookies;
+pub use cookies::{Cookies, CookiesMut};
 
 #[macro_use] pub mod macros;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ extern crate groupable;
 extern crate modifier;
 extern crate cookie;
 extern crate byteorder;
+extern crate rand;
 
 #[macro_use] extern crate log;
 #[macro_use] extern crate lazy_static;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ pub use router::{Router, Route, RouteResult, HttpRouter};
 pub use nickel_error::NickelError;
 pub use mimes::MediaType;
 pub use responder::Responder;
-pub use cookies::{Cookies, CookiesMut};
+pub use cookies::Cookies;
 
 #[macro_use] pub mod macros;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,8 @@ pub use nickel_error::NickelError;
 pub use mimes::MediaType;
 pub use responder::Responder;
 pub use cookies::Cookies;
+
+#[cfg(feature = "session")]
 pub use session::{Session, SessionStore, CookieSession};
 
 #[macro_use] pub mod macros;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub use responder::Responder;
 pub use cookies::Cookies;
 
 #[cfg(feature = "session")]
-pub use session::{Session, SessionStore, CookieSession};
+pub use session::{Session, CookieSession};
 
 #[macro_use] pub mod macros;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ extern crate mustache;
 extern crate groupable;
 extern crate modifier;
 extern crate cookie;
+extern crate byteorder;
 
 #[macro_use] extern crate log;
 #[macro_use] extern crate lazy_static;
@@ -30,6 +31,7 @@ pub use nickel_error::NickelError;
 pub use mimes::MediaType;
 pub use responder::Responder;
 pub use cookies::Cookies;
+pub use session::{Session, SessionStore, CookieSession};
 
 #[macro_use] pub mod macros;
 
@@ -50,6 +52,7 @@ mod urlencoded;
 mod nickel_error;
 mod default_error_handler;
 pub mod cookies;
+pub mod session;
 
 pub mod status {
     pub use hyper::status::StatusCode;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ extern crate url;
 extern crate mustache;
 extern crate groupable;
 extern crate modifier;
+extern crate cookie;
 
 #[macro_use] extern crate log;
 #[macro_use] extern crate lazy_static;
@@ -28,6 +29,7 @@ pub use router::{Router, Route, RouteResult, HttpRouter};
 pub use nickel_error::NickelError;
 pub use mimes::MediaType;
 pub use responder::Responder;
+pub use cookies::Cookies;
 
 #[macro_use] pub mod macros;
 
@@ -47,6 +49,7 @@ mod query_string;
 mod urlencoded;
 mod nickel_error;
 mod default_error_handler;
+pub mod cookies;
 
 pub mod status {
     pub use hyper::status::StatusCode;

--- a/src/macros/middleware.rs
+++ b/src/macros/middleware.rs
@@ -23,8 +23,29 @@
 /// server.listen("127.0.0.1:6767");
 /// # }
 /// ```
+///
+/// # Type hinting
+/// Sometimes type inference is unable to determine the datatype for the server,
+/// which can lead to a lot of extra type annotations. The `middleware!` macro
+/// supports annotating the macro so as to drive the inference allowing the handler
+/// code to remain with minimal annotations.
+///
+/// ```
+/// # #[macro_use] extern crate nickel;
+/// # fn main() {
+/// # struct MyServerData;
+/// middleware! { |_request, _response| <MyServerData>
+///     // _response is of type Response<MyServerData>
+///     "Hello World"
+/// }
+/// # ; // This semicolon is required to satisfy returning `()`
+/// # }
+/// ```
 #[macro_export]
 macro_rules! middleware {
+    (|$req:tt, mut $res:ident| <$data:path> $($b:tt)+) => { _middleware_inner!($req, $res, mut $res, <$data> $($b)+) };
+    (|$req:tt, $res:ident| <$data:path> $($b:tt)+) => { _middleware_inner!($req, $res, $res, <$data> $($b)+) };
+    (|$req:tt| <$data:path> $($b:tt)+) => { middleware!(|$req, _res| <$data> $($b)+) };
     (|$req:tt, mut $res:ident| $($b:tt)+) => { _middleware_inner!($req, $res, mut $res, $($b)+) };
     (|$req:tt, $res:ident| $($b:tt)+) => { _middleware_inner!($req, $res, $res, $($b)+) };
     (|$req:tt| $($b:tt)+) => { middleware!(|$req, _res| $($b)+) };
@@ -34,7 +55,28 @@ macro_rules! middleware {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! _middleware_inner {
-    ($req:tt, $res:ident, $res_binding:pat, $($b:tt)+) => {{
+    ($req:tt, $res:ident, $res_binding:pat, <$data:path> $($b:tt)+) => {{
+        use $crate::{MiddlewareResult,Responder, Response, Request};
+
+        #[inline(always)]
+        fn restrict<'mw, R: Responder<$data>>(r: R, res: Response<'mw, $data>)
+                -> MiddlewareResult<'mw, $data> {
+            res.send(r)
+        }
+
+        // Inference fails due to thinking it's a (&Request, Response) with
+        // different mutability requirements
+        #[inline(always)]
+        fn restrict_closure<F>(f: F) -> F
+            where F: for<'r, 'mw, 'conn>
+                        Fn(&'r mut Request<'mw, 'conn, $data>, Response<'mw, $data>)
+                            -> MiddlewareResult<'mw, $data> + Send + Sync { f }
+
+        restrict_closure(move |as_pat!($req), $res_binding| {
+            restrict(as_block!({$($b)+}), $res)
+        })
+    }};
+    ($req:tt, $res:ident, $res_binding:pat,  $($b:tt)+) => {{
         use $crate::{MiddlewareResult,Responder, Response, Request};
 
         #[inline(always)]

--- a/src/macros/middleware.rs
+++ b/src/macros/middleware.rs
@@ -38,18 +38,18 @@ macro_rules! _middleware_inner {
         use $crate::{MiddlewareResult,Responder, Response, Request};
 
         #[inline(always)]
-        fn restrict<'mw, R: Responder>(r: R, res: Response<'mw>)
-                -> MiddlewareResult<'mw> {
+        fn restrict<'mw, D, R: Responder<D>>(r: R, res: Response<'mw, D>)
+                -> MiddlewareResult<'mw, D> {
             res.send(r)
         }
 
         // Inference fails due to thinking it's a (&Request, Response) with
         // different mutability requirements
         #[inline(always)]
-        fn restrict_closure<F>(f: F) -> F
+        fn restrict_closure<F, D>(f: F) -> F
             where F: for<'r, 'mw, 'conn>
-                        Fn(&'r mut Request<'mw, 'conn>, Response<'mw>)
-                            -> MiddlewareResult<'mw> + Send + Sync { f }
+                        Fn(&'r mut Request<'mw, 'conn, D>, Response<'mw, D>)
+                            -> MiddlewareResult<'mw, D> + Send + Sync { f }
 
         restrict_closure(move |as_pat!($req), $res_binding| {
             restrict(as_block!({$($b)+}), $res)

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -5,9 +5,9 @@ use hyper::net;
 
 pub use self::Action::{Continue, Halt};
 
-pub type MiddlewareResult<'mw> = Result<Action<Response<'mw, net::Fresh>,
-                                              Response<'mw, net::Streaming>>,
-                                        NickelError<'mw>>;
+pub type MiddlewareResult<'mw, D> = Result<Action<Response<'mw, D, net::Fresh>,
+                                              Response<'mw, D, net::Streaming>>,
+                                        NickelError<'mw, D>>;
 
 pub enum Action<T=(), U=()> {
     Continue(T),
@@ -16,43 +16,43 @@ pub enum Action<T=(), U=()> {
 
 // the usage of + Send is weird here because what we really want is + Static
 // but that's not possible as of today. We have to use + Send for now.
-pub trait Middleware: Send + 'static + Sync {
-    fn invoke<'mw, 'conn>(&'mw self, _req: &mut Request<'mw, 'conn>, res: Response<'mw, net::Fresh>) -> MiddlewareResult<'mw> {
+pub trait Middleware<D>: Send + 'static + Sync {
+    fn invoke<'mw, 'conn>(&'mw self, _req: &mut Request<'mw, 'conn, D>, res: Response<'mw, D, net::Fresh>) -> MiddlewareResult<'mw, D> {
         Ok(Continue(res))
     }
 }
 
-impl<T> Middleware for T where T: for<'r, 'mw, 'conn> Fn(&'r mut Request<'mw, 'conn>, Response<'mw>) -> MiddlewareResult<'mw> + Send + Sync + 'static {
-    fn invoke<'mw, 'conn>(&'mw self, req: &mut Request<'mw, 'conn>, res: Response<'mw>) -> MiddlewareResult<'mw> {
+impl<T, D> Middleware<D> for T where T: for<'r, 'mw, 'conn> Fn(&'r mut Request<'mw, 'conn, D>, Response<'mw, D>) -> MiddlewareResult<'mw, D> + Send + Sync + 'static {
+    fn invoke<'mw, 'conn>(&'mw self, req: &mut Request<'mw, 'conn, D>, res: Response<'mw, D>) -> MiddlewareResult<'mw, D> {
         (*self)(req, res)
     }
 }
 
-pub trait ErrorHandler: Send + 'static + Sync {
-    fn handle_error(&self, &mut NickelError, &mut Request) -> Action;
+pub trait ErrorHandler<D>: Send + 'static + Sync {
+    fn handle_error(&self, &mut NickelError<D>, &mut Request<D>) -> Action;
 }
 
-impl ErrorHandler for fn(&mut NickelError, &mut Request) -> Action {
-    fn handle_error(&self, err: &mut NickelError, req: &mut Request) -> Action {
+impl<D> ErrorHandler<D> for fn(&mut NickelError<D>, &mut Request<D>) -> Action {
+    fn handle_error(&self, err: &mut NickelError<D>, req: &mut Request<D>) -> Action {
         (*self)(err, req)
     }
 }
 
-pub struct MiddlewareStack {
-    handlers: Vec<Box<Middleware + Send + Sync>>,
-    error_handlers: Vec<Box<ErrorHandler + Send + Sync>>
+pub struct MiddlewareStack<D> {
+    handlers: Vec<Box<Middleware<D> + Send + Sync>>,
+    error_handlers: Vec<Box<ErrorHandler<D> + Send + Sync>>
 }
 
-impl MiddlewareStack {
-    pub fn add_middleware<T: Middleware> (&mut self, handler: T) {
+impl<D> MiddlewareStack<D> {
+    pub fn add_middleware<T: Middleware<D>> (&mut self, handler: T) {
         self.handlers.push(Box::new(handler));
     }
 
-    pub fn add_error_handler<T: ErrorHandler> (&mut self, handler: T) {
+    pub fn add_error_handler<T: ErrorHandler<D>> (&mut self, handler: T) {
         self.error_handlers.push(Box::new(handler));
     }
 
-    pub fn invoke<'mw, 'conn>(&'mw self, mut req: Request<'mw, 'conn>, mut res: Response<'mw>) {
+    pub fn invoke<'mw, 'conn>(&'mw self, mut req: Request<'mw, 'conn, D>, mut res: Response<'mw, D>) {
         for handler in self.handlers.iter() {
             match handler.invoke(&mut req, res) {
                 Ok(Halt(res)) => {
@@ -92,7 +92,7 @@ impl MiddlewareStack {
         }
     }
 
-    pub fn new () -> MiddlewareStack {
+    pub fn new () -> MiddlewareStack<D> {
         MiddlewareStack{
             handlers: Vec::new(),
             error_handlers: Vec::new()

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -32,7 +32,7 @@ pub trait ErrorHandler<D>: Send + 'static + Sync {
     fn handle_error(&self, &mut NickelError<D>, &mut Request<D>) -> Action;
 }
 
-impl<D> ErrorHandler<D> for fn(&mut NickelError<D>, &mut Request<D>) -> Action {
+impl<D: 'static> ErrorHandler<D> for fn(&mut NickelError<D>, &mut Request<D>) -> Action {
     fn handle_error(&self, err: &mut NickelError<D>, req: &mut Request<D>) -> Action {
         (*self)(err, req)
     }
@@ -43,7 +43,7 @@ pub struct MiddlewareStack<D> {
     error_handlers: Vec<Box<ErrorHandler<D> + Send + Sync>>
 }
 
-impl<D> MiddlewareStack<D> {
+impl<D: 'static> MiddlewareStack<D> {
     pub fn add_middleware<T: Middleware<D>> (&mut self, handler: T) {
         self.handlers.push(Box::new(handler));
     }

--- a/src/nickel.rs
+++ b/src/nickel.rs
@@ -10,12 +10,13 @@ use default_error_handler::DefaultErrorHandler;
 
 /// Nickel is the application object. It's the surface that
 /// holds all public APIs.
-pub struct Nickel{
-    middleware_stack: MiddlewareStack,
+pub struct Nickel<D: Sync + Send + 'static = ()> {
+    middleware_stack: MiddlewareStack<D>,
+    data: D
 }
 
-impl HttpRouter for Nickel {
-    fn add_route<M: Into<Matcher>, H: Middleware>(&mut self, method: Method, matcher: M, handler: H) -> &mut Self {
+impl<D: Sync + Send + 'static> HttpRouter<D> for Nickel<D> {
+    fn add_route<M: Into<Matcher>, H: Middleware<D>>(&mut self, method: Method, matcher: M, handler: H) -> &mut Self {
         let mut router = Router::new();
         router.add_route(method, matcher, handler);
         self.utilize(router);
@@ -23,9 +24,16 @@ impl HttpRouter for Nickel {
     }
 }
 
-impl Nickel {
+impl Nickel<()> {
     /// Creates an instance of Nickel with default error handling.
-    pub fn new() -> Nickel {
+    pub fn new() -> Nickel<()> {
+        Nickel::with_data(())
+    }
+}
+
+impl<D: Sync + Send + 'static> Nickel<D> {
+    /// Creates an instance of Nickel with default error handling and custom data.
+    pub fn with_data(data: D) -> Nickel<D> {
         let mut middleware_stack = MiddlewareStack::new();
 
         // Hook up the default error handler by default. Users are
@@ -33,7 +41,10 @@ impl Nickel {
         // they don't like the default behaviour.
         middleware_stack.add_error_handler(DefaultErrorHandler);
 
-        Nickel { middleware_stack: middleware_stack }
+        Nickel {
+            middleware_stack: middleware_stack,
+            data: data
+        }
     }
 
     /// Registers a middleware handler which will be invoked among other middleware
@@ -57,7 +68,7 @@ impl Nickel {
     /// });
     /// # }
     /// ```
-    pub fn utilize<T: Middleware>(&mut self, handler: T){
+    pub fn utilize<T: Middleware<D>>(&mut self, handler: T){
         self.middleware_stack.add_middleware(handler);
     }
 
@@ -77,7 +88,7 @@ impl Nickel {
     /// use nickel::{NickelError, Action};
     /// use nickel::status::StatusCode::NotFound;
     ///
-    /// fn error_handler(err: &mut NickelError, _req: &mut Request) -> Action {
+    /// fn error_handler<D>(err: &mut NickelError<D>, _req: &mut Request<D>) -> Action {
     ///    if let Some(ref mut res) = err.stream {
     ///        if res.status() == NotFound {
     ///            let _ = res.write_all(b"<h1>Call the police!</h1>");
@@ -90,12 +101,12 @@ impl Nickel {
     ///
     /// let mut server = Nickel::new();
     ///
-    /// let ehandler: fn(&mut NickelError, &mut Request) -> Action = error_handler;
+    /// let ehandler: fn(&mut NickelError<()>, &mut Request<()>) -> Action = error_handler;
     ///
     /// server.handle_error(ehandler)
     /// # }
     /// ```
-    pub fn handle_error<T: ErrorHandler>(&mut self, handler: T){
+    pub fn handle_error<T: ErrorHandler<D>>(&mut self, handler: T){
         self.middleware_stack.add_error_handler(handler);
     }
 
@@ -118,7 +129,7 @@ impl Nickel {
     ///     server.utilize(router);
     /// }
     /// ```
-    pub fn router() -> Router {
+    pub fn router() -> Router<D> {
         Router::new()
     }
 
@@ -140,7 +151,7 @@ impl Nickel {
             (StatusCode::NotFound, "File Not Found")
         });
 
-        let server = Server::new(self.middleware_stack);
+        let server = Server::new(self.middleware_stack, self.data);
         let listener = server.serve(addr).unwrap();
 
         println!("Listening on http://{}", listener.socket);

--- a/src/nickel_error.rs
+++ b/src/nickel_error.rs
@@ -7,12 +7,12 @@ use hyper::net::{Fresh, Streaming};
 
 /// NickelError is the basic error type for HTTP errors as well as user defined errors.
 /// One can pattern match against the `kind` property to handle the different cases.
-pub struct NickelError<'a> {
-    pub stream: Option<Response<'a, Streaming>>,
+pub struct NickelError<'a, D: 'a> {
+    pub stream: Option<Response<'a, D, Streaming>>,
     pub message: Cow<'static, str>
 }
 
-impl<'a> NickelError<'a> {
+impl<'a, D> NickelError<'a, D> {
     /// Creates a new `NickelError` instance.
     ///
     /// You should probably use `Response#error` in favor of this.
@@ -26,14 +26,14 @@ impl<'a> NickelError<'a> {
     /// use nickel::status::StatusCode;
     ///
     /// # #[allow(dead_code)]
-    /// fn handler<'a>(_: &mut Request, res: Response<'a>) -> MiddlewareResult<'a> {
+    /// fn handler<'a, D>(_: &mut Request<D>, res: Response<'a, D>) -> MiddlewareResult<'a, D> {
     ///     Err(NickelError::new(res, "Error Parsing JSON", StatusCode::BadRequest))
     /// }
     /// # }
     /// ```
-    pub fn new<T>(mut stream: Response<'a, Fresh>,
+    pub fn new<T>(mut stream: Response<'a, D, Fresh>,
                   message: T,
-                  status_code: StatusCode) -> NickelError<'a>
+                  status_code: StatusCode) -> NickelError<'a, D>
             where T: Into<Cow<'static, str>> {
         stream.set(status_code);
 
@@ -56,7 +56,7 @@ impl<'a> NickelError<'a> {
     ///
     /// This is considered `unsafe` as deadlock can occur if the `Response`
     /// does not have the underlying stream flushed when processing is finished.
-    pub unsafe fn without_response<T>(message: T) -> NickelError<'a>
+    pub unsafe fn without_response<T>(message: T) -> NickelError<'a, D>
             where T: Into<Cow<'static, str>> {
         NickelError {
             stream: None,
@@ -69,22 +69,22 @@ impl<'a> NickelError<'a> {
     }
 }
 
-impl<'a, T> From<(Response<'a>, (StatusCode, T))> for NickelError<'a>
+impl<'a, T, D> From<(Response<'a, D>, (StatusCode, T))> for NickelError<'a, D>
         where T: Into<Box<Error + 'static>> {
-    fn from((res, (errorcode, err)): (Response<'a>, (StatusCode, T))) -> NickelError<'a> {
+    fn from((res, (errorcode, err)): (Response<'a, D>, (StatusCode, T))) -> NickelError<'a, D> {
         let err = err.into();
         NickelError::new(res, err.description().to_string(), errorcode)
     }
 }
 
-impl<'a> From<(Response<'a>, String)> for NickelError<'a> {
-    fn from((res, msg): (Response<'a>, String)) -> NickelError<'a> {
+impl<'a, D> From<(Response<'a, D>, String)> for NickelError<'a, D> {
+    fn from((res, msg): (Response<'a, D>, String)) -> NickelError<'a, D> {
         NickelError::new(res, msg, StatusCode::InternalServerError)
     }
 }
 
-impl<'a> From<(Response<'a>, StatusCode)> for NickelError<'a> {
-    fn from((res, code): (Response<'a>, StatusCode)) -> NickelError<'a> {
+impl<'a, D> From<(Response<'a, D>, StatusCode)> for NickelError<'a, D> {
+    fn from((res, code): (Response<'a, D>, StatusCode)) -> NickelError<'a, D> {
         NickelError::new(res, "", code)
     }
 }

--- a/src/query_string.rs
+++ b/src/query_string.rs
@@ -33,10 +33,10 @@ impl Query {
 struct QueryStringParser;
 impl Key for QueryStringParser { type Value = Query; }
 
-impl<'mw, 'conn> Plugin<Request<'mw, 'conn>> for QueryStringParser {
+impl<'mw, 'conn, D> Plugin<Request<'mw, 'conn, D>> for QueryStringParser {
     type Error = ();
 
-    fn eval(req: &mut Request) -> Result<Query, ()> {
+    fn eval(req: &mut Request<D>) -> Result<Query, ()> {
         Ok(parse(&req.origin.uri))
     }
 }
@@ -46,7 +46,7 @@ pub trait QueryString {
     fn query(&mut self) -> &Query;
 }
 
-impl<'mw, 'conn> QueryString for Request<'mw, 'conn> {
+impl<'mw, 'conn, D> QueryString for Request<'mw, 'conn, D> {
     fn query(&mut self) -> &Query {
         self.get_ref::<QueryStringParser>()
             .ok()

--- a/src/request.rs
+++ b/src/request.rs
@@ -43,6 +43,10 @@ impl<'mw, 'server, D> Request<'mw, 'server, D> {
             _ => None
         }
     }
+
+    pub fn data(&self) -> &D {
+        &self.data
+    }
 }
 
 impl<'mw, 'server, D> Extensible for Request<'mw, 'server, D> {

--- a/src/request.rs
+++ b/src/request.rs
@@ -11,21 +11,25 @@ use hyper::uri::RequestUri::AbsolutePath;
 ///
 /// The lifetime `'server` represents the lifetime of data internal to
 /// the server. It is fixed and longer than `'mw`.
-pub struct Request<'mw, 'server: 'mw> {
+pub struct Request<'mw, 'server: 'mw, D: 'mw> {
     ///the original `hyper::server::Request`
     pub origin: HyperRequest<'mw, 'server>,
     ///a `HashMap<String, String>` holding all params with names and values
-    pub route_result: Option<RouteResult<'mw>>,
+    pub route_result: Option<RouteResult<'mw, D>>,
 
-    map: TypeMap
+    map: TypeMap,
+
+    data: &'mw D,
 }
 
-impl<'mw, 'server> Request<'mw, 'server> {
-    pub fn from_internal(req: HyperRequest<'mw, 'server>) -> Request<'mw, 'server> {
+impl<'mw, 'server, D> Request<'mw, 'server, D> {
+    pub fn from_internal(req: HyperRequest<'mw, 'server>,
+                         data: &'mw D) -> Request<'mw, 'server, D> {
         Request {
             origin: req,
             route_result: None,
-            map: TypeMap::new()
+            map: TypeMap::new(),
+            data: data
         }
     }
 
@@ -41,7 +45,7 @@ impl<'mw, 'server> Request<'mw, 'server> {
     }
 }
 
-impl<'mw, 'server> Extensible for Request<'mw, 'server> {
+impl<'mw, 'server, D> Extensible for Request<'mw, 'server, D> {
     fn extensions(&self) -> &TypeMap {
         &self.map
     }
@@ -51,4 +55,4 @@ impl<'mw, 'server> Extensible for Request<'mw, 'server> {
     }
 }
 
-impl<'mw, 'server> Pluggable for Request<'mw, 'server> {}
+impl<'mw, 'server, D> Pluggable for Request<'mw, 'server, D> {}

--- a/src/response.rs
+++ b/src/response.rs
@@ -23,19 +23,22 @@ use modifier::Modifier;
 pub type TemplateCache = RwLock<HashMap<String, Template>>;
 
 ///A container for the response
-pub struct Response<'a, T: 'static + Any = Fresh> {
+pub struct Response<'a, D: 'a, T: 'static + Any = Fresh> {
     ///the original `hyper::server::Response`
     origin: HyperResponse<'a, T>,
-    templates: &'a TemplateCache
+    templates: &'a TemplateCache,
+    data: &'a D,
 }
 
-impl<'a> Response<'a, Fresh> {
+impl<'a, D> Response<'a, D, Fresh> {
     pub fn from_internal<'c, 'd>(response: HyperResponse<'c, Fresh>,
-                                 templates: &'c TemplateCache)
-                                -> Response<'c, Fresh> {
+                                 templates: &'c TemplateCache,
+                                 data: &'c D)
+                                -> Response<'c, D, Fresh> {
         Response {
             origin: response,
-            templates: templates
+            templates: templates,
+            data: data
         }
     }
 
@@ -81,7 +84,7 @@ impl<'a> Response<'a, Fresh> {
     ///     // ...
     /// }
     /// ```
-    pub fn set<T: Modifier<Response<'a>>>(&mut self, attribute: T) -> &mut Response<'a> {
+    pub fn set<T: Modifier<Response<'a, D>>>(&mut self, attribute: T) -> &mut Response<'a, D> {
         attribute.modify(self);
         self
     }
@@ -93,12 +96,12 @@ impl<'a> Response<'a, Fresh> {
     /// use nickel::{Request, Response, MiddlewareResult};
     ///
     /// # #[allow(dead_code)]
-    /// fn handler<'a>(_: &mut Request, res: Response<'a>) -> MiddlewareResult<'a> {
+    /// fn handler<'a, D>(_: &mut Request<D>, res: Response<'a, D>) -> MiddlewareResult<'a, D> {
     ///     res.send("hello world")
     /// }
     /// ```
     #[inline]
-    pub fn send<T: Responder>(self, data: T) -> MiddlewareResult<'a> {
+    pub fn send<T: Responder<D>>(self, data: T) -> MiddlewareResult<'a, D> {
         data.respond(self)
     }
 
@@ -110,12 +113,12 @@ impl<'a> Response<'a, Fresh> {
     /// use std::path::Path;
     ///
     /// # #[allow(dead_code)]
-    /// fn handler<'a>(_: &mut Request, res: Response<'a>) -> MiddlewareResult<'a> {
+    /// fn handler<'a, D>(_: &mut Request<D>, res: Response<'a, D>) -> MiddlewareResult<'a, D> {
     ///     let favicon = Path::new("/assets/favicon.ico");
     ///     res.send_file(favicon)
     /// }
     /// ```
-    pub fn send_file<P:AsRef<Path>>(mut self, path: P) -> MiddlewareResult<'a> {
+    pub fn send_file<P:AsRef<Path>>(mut self, path: P) -> MiddlewareResult<'a, D> {
         let path = path.as_ref();
         // Chunk the response
         self.origin.headers_mut().remove::<ContentLength>();
@@ -147,7 +150,7 @@ impl<'a> Response<'a, Fresh> {
 
     /// Return an error with the appropriate status code for error handlers to
     /// provide output for.
-    pub fn error<T>(self, status: StatusCode, message: T) -> MiddlewareResult<'a>
+    pub fn error<T>(self, status: StatusCode, message: T) -> MiddlewareResult<'a, D>
             where T: Into<Cow<'static, str>> {
         Err(NickelError::new(self, message, status))
     }
@@ -195,16 +198,16 @@ impl<'a> Response<'a, Fresh> {
     /// use nickel::{Request, Response, MiddlewareResult};
     ///
     /// # #[allow(dead_code)]
-    /// fn handler<'a>(_: &mut Request, res: Response<'a>) -> MiddlewareResult<'a> {
+    /// fn handler<'a, D>(_: &mut Request<D>, res: Response<'a, D>) -> MiddlewareResult<'a, D> {
     ///     let mut data = HashMap::new();
     ///     data.insert("name", "user");
     ///     res.render("examples/assets/template.tpl", &data)
     /// }
     /// ```
-    pub fn render<T, P>(self, path: P, data: &T) -> MiddlewareResult<'a>
+    pub fn render<T, P>(self, path: P, data: &T) -> MiddlewareResult<'a, D>
             where T: Encodable, P: AsRef<str> + Into<String> {
-        fn render<'a, T>(res: Response<'a>, template: &Template, data: &T)
-                -> MiddlewareResult<'a> where T: Encodable {
+        fn render<'a, D, T>(res: Response<'a, D>, template: &Template, data: &T)
+                -> MiddlewareResult<'a, D> where T: Encodable {
             let mut stream = try!(res.start());
             match template.render(&mut stream, data) {
                 Ok(()) => Ok(Halt(stream)),
@@ -239,12 +242,18 @@ impl<'a> Response<'a, Fresh> {
         render(self, template, data)
     }
 
-    pub fn start(mut self) -> Result<Response<'a, Streaming>, NickelError<'a>> {
+    pub fn start(mut self) -> Result<Response<'a, D, Streaming>, NickelError<'a, D>> {
         self.set_fallback_headers();
 
-        let Response { origin, templates } = self;
+        let Response { origin, templates, data } = self;
         match origin.start() {
-            Ok(origin) => Ok(Response { origin: origin, templates: templates }),
+            Ok(origin) => {
+                Ok(Response {
+                    origin: origin,
+                    templates: templates,
+                    data: data
+                })
+            },
             Err(e) =>
                 unsafe {
                     Err(NickelError::without_response(format!("Failed to start response: {}", e)))
@@ -253,7 +262,7 @@ impl<'a> Response<'a, Fresh> {
     }
 }
 
-impl<'a, 'b> Write for Response<'a, Streaming> {
+impl<'a, 'b, D> Write for Response<'a, D, Streaming> {
     #[inline(always)]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.origin.write(buf)
@@ -265,12 +274,12 @@ impl<'a, 'b> Write for Response<'a, Streaming> {
     }
 }
 
-impl<'a, 'b> Response<'a, Streaming> {
+impl<'a, 'b, D> Response<'a, D, Streaming> {
     /// In the case of an unrecoverable error while a stream is already in
     /// progress, there is no standard way to signal to the client that an
     /// error has occurred. `bail` will drop the connection and log an error
     /// message.
-    pub fn bail<T>(self, message: T) -> MiddlewareResult<'a>
+    pub fn bail<T>(self, message: T) -> MiddlewareResult<'a, D>
             where T: Into<Cow<'static, str>> {
         let _ = self.end();
         unsafe { Err(NickelError::without_response(message)) }
@@ -282,7 +291,7 @@ impl<'a, 'b> Response<'a, Streaming> {
     }
 }
 
-impl <'a, T: 'static + Any> Response<'a, T> {
+impl <'a, D, T: 'static + Any> Response<'a, D, T> {
     /// The status of this response.
     pub fn status(&self) -> StatusCode {
         self.origin.status()
@@ -315,14 +324,14 @@ mod modifier_impls {
     use modifier::Modifier;
     use {Response, MediaType};
 
-    impl<'a> Modifier<Response<'a>> for StatusCode {
-        fn modify(self, res: &mut Response<'a>) {
+    impl<'a, D> Modifier<Response<'a, D>> for StatusCode {
+        fn modify(self, res: &mut Response<'a, D>) {
             *res.status_mut() = self
         }
     }
 
-    impl<'a> Modifier<Response<'a>> for MediaType {
-        fn modify(self, res: &mut Response<'a>) {
+    impl<'a, D> Modifier<Response<'a, D>> for MediaType {
+        fn modify(self, res: &mut Response<'a, D>) {
             ContentType(self.into()).modify(res)
         }
     }
@@ -330,8 +339,8 @@ mod modifier_impls {
     macro_rules! header_modifiers {
         ($($t:ty),+) => (
             $(
-                impl<'a> Modifier<Response<'a>> for $t {
-                    fn modify(self, res: &mut Response<'a>) {
+                impl<'a, D> Modifier<Response<'a, D>> for $t {
+                    fn modify(self, res: &mut Response<'a, D>) {
                         res.headers_mut().set(self)
                     }
                 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -252,7 +252,7 @@ impl<'a, D> Response<'a, D, Fresh> {
 
     pub fn start(mut self) -> Result<Response<'a, D, Streaming>, NickelError<'a, D>> {
         let on_send = mem::replace(&mut self.on_send, vec![]);
-        for mut f in on_send.into_iter() {
+        for mut f in on_send.into_iter().rev() {
             // TODO: Ensure `f` doesn't call on_send again
             f(&mut self)
         }

--- a/src/router/http_router.rs
+++ b/src/router/http_router.rs
@@ -2,7 +2,7 @@ use hyper::method::Method;
 use middleware::Middleware;
 use router::Matcher;
 
-pub trait HttpRouter {
+pub trait HttpRouter<D> {
     /// Registers a handler to be used for a specified method.
     /// A handler can be anything implementing the `RequestHandler` trait.
     ///
@@ -36,7 +36,7 @@ pub trait HttpRouter {
     ///     server.add_route(Get, regex, middleware! { "Regex Get request! "});
     /// }
     /// ```
-    fn add_route<M: Into<Matcher>, H: Middleware>(&mut self, Method, M, H) -> &mut Self;
+    fn add_route<M: Into<Matcher>, H: Middleware<D>>(&mut self, Method, M, H) -> &mut Self;
 
     /// Registers a handler to be used for a specific GET request.
     /// Handlers are assigned to paths and paths are allowed to contain
@@ -121,42 +121,42 @@ pub trait HttpRouter {
     ///     server.utilize(router);
     /// }
     /// ```
-    fn get<M: Into<Matcher>, H: Middleware>(&mut self, matcher: M, handler: H) -> &mut Self {
+    fn get<M: Into<Matcher>, H: Middleware<D>>(&mut self, matcher: M, handler: H) -> &mut Self {
         self.add_route(Method::Get, matcher, handler)
     }
 
     /// Registers a handler to be used for a specific POST request.
     ///
     /// Take a look at `get(...)` for a more detailed description.
-    fn post<M: Into<Matcher>, H: Middleware>(&mut self, matcher: M, handler: H) -> &mut Self {
+    fn post<M: Into<Matcher>, H: Middleware<D>>(&mut self, matcher: M, handler: H) -> &mut Self {
         self.add_route(Method::Post, matcher, handler)
     }
 
     /// Registers a handler to be used for a specific PUT request.
     ///
     /// Take a look at `get(...)` for a more detailed description.
-    fn put<M: Into<Matcher>, H: Middleware>(&mut self, matcher: M, handler: H) -> &mut Self {
+    fn put<M: Into<Matcher>, H: Middleware<D>>(&mut self, matcher: M, handler: H) -> &mut Self {
         self.add_route(Method::Put, matcher, handler)
     }
 
     /// Registers a handler to be used for a specific DELETE request.
     ///
     /// Take a look at `get(...)` for a more detailed description.
-    fn delete<M: Into<Matcher>, H: Middleware>(&mut self, matcher: M, handler: H) -> &mut Self {
+    fn delete<M: Into<Matcher>, H: Middleware<D>>(&mut self, matcher: M, handler: H) -> &mut Self {
         self.add_route(Method::Delete, matcher, handler)
     }
 
     /// Registers a handler to be used for a specific OPTIONS request.
     ///
     /// Take a look at `get(...)` for a more detailed description.
-    fn options<M: Into<Matcher>, H: Middleware>(&mut self, matcher: M, handler: H) -> &mut Self {
+    fn options<M: Into<Matcher>, H: Middleware<D>>(&mut self, matcher: M, handler: H) -> &mut Self {
         self.add_route(Method::Options, matcher, handler)
     }
 
     /// Registers a handler to be used for a specific PATCH request.
     ///
     /// Take a look at `get(...)` for a more detailed description.
-    fn patch<M: Into<Matcher>, H: Middleware>(&mut self, matcher: M, handler: H) -> &mut Self {
+    fn patch<M: Into<Matcher>, H: Middleware<D>>(&mut self, matcher: M, handler: H) -> &mut Self {
         self.add_route(Method::Patch, matcher, handler)
     }
 }

--- a/src/router/router.rs
+++ b/src/router/router.rs
@@ -10,9 +10,9 @@ use router::{Matcher, FORMAT_PARAM};
 /// A Route is the basic data structure that stores both the path
 /// and the handler that gets executed for the route.
 /// The path can contain variable pattern such as `user/:userid/invoices`
-pub struct Route {
+pub struct Route<D=()> {
     pub method: Method,
-    pub handler: Box<Middleware + Send + Sync + 'static>,
+    pub handler: Box<Middleware<D> + Send + Sync + 'static>,
     matcher: Matcher
 }
 
@@ -20,12 +20,12 @@ pub struct Route {
 /// It contains the matched `route` and also a `params` property holding
 /// a HashMap with the keys being the variable names and the value being the
 /// evaluated string
-pub struct RouteResult<'mw> {
-    pub route: &'mw Route,
+pub struct RouteResult<'mw, D: 'mw> {
+    pub route: &'mw Route<D>,
     params: Vec<(String, String)>
 }
 
-impl<'mw> RouteResult<'mw> {
+impl<'mw, D> RouteResult<'mw, D> {
     pub fn param(&self, key: &str) -> Option<&str> {
         for &(ref k, ref v) in &self.params {
             if k == &key {
@@ -45,18 +45,18 @@ impl<'mw> RouteResult<'mw> {
 /// The Router's job is it to hold routes and to resolve them later against
 /// concrete URLs. The router is also a regular middleware and needs to be
 /// added to the middleware stack with `server.utilize(router)`.
-pub struct Router {
-    routes: Vec<Route>,
+pub struct Router<D=()> {
+    routes: Vec<Route<D>>,
 }
 
-impl Router {
-    pub fn new () -> Router {
+impl<D=()> Router<D> {
+    pub fn new() -> Router<D> {
         Router {
             routes: Vec::new()
         }
     }
 
-    pub fn match_route<'mw>(&'mw self, method: &Method, path: &str) -> Option<RouteResult<'mw>> {
+    pub fn match_route<'mw>(&'mw self, method: &Method, path: &str) -> Option<RouteResult<'mw, D>> {
         self.routes
             .iter()
             .find(|item| item.method == *method && item.matcher.is_match(path))
@@ -69,7 +69,7 @@ impl Router {
     }
 }
 
-fn extract_params(route: &Route, path: &str) -> Vec<(String, String)> {
+fn extract_params<D>(route: &Route<D>, path: &str) -> Vec<(String, String)> {
     match route.matcher.captures(path) {
         Some(captures) => {
             captures.iter_named()
@@ -82,8 +82,8 @@ fn extract_params(route: &Route, path: &str) -> Vec<(String, String)> {
     }
 }
 
-impl HttpRouter for Router {
-    fn add_route<M: Into<Matcher>, H: Middleware>(&mut self, method: Method, matcher: M, handler: H) -> &mut Self {
+impl<D> HttpRouter<D> for Router<D> {
+    fn add_route<M: Into<Matcher>, H: Middleware<D>>(&mut self, method: Method, matcher: M, handler: H) -> &mut Self {
         let route = Route {
             matcher: matcher.into(),
             method: method,
@@ -95,9 +95,9 @@ impl HttpRouter for Router {
     }
 }
 
-impl Middleware for Router {
-    fn invoke<'mw, 'conn>(&'mw self, req: &mut Request<'mw, 'conn>, mut res: Response<'mw>)
-                          -> MiddlewareResult<'mw> {
+impl<D: 'static> Middleware<D> for Router<D> {
+    fn invoke<'mw, 'conn>(&'mw self, req: &mut Request<'mw, 'conn, D>, mut res: Response<'mw, D>)
+                          -> MiddlewareResult<'mw, D> {
         debug!("Router::invoke for '{:?}'", req.origin.uri);
 
         // Strip off the querystring when matching a route
@@ -191,7 +191,7 @@ fn creates_valid_regex_for_routes () {
 
 #[test]
 fn can_match_var_routes () {
-    let route_store = &mut Router::new();
+    let route_store = &mut Router::<()>::new();
 
     route_store.add_route(Method::Get, "/foo/:userid", middleware! { "hello from foo" });
     route_store.add_route(Method::Get, "/bar", middleware! { "hello from foo" });
@@ -256,7 +256,7 @@ fn can_match_var_routes () {
 
 #[test]
 fn params_lifetime() {
-    let route_store = &mut Router::new();
+    let route_store = &mut Router::<()>::new();
     let handler = middleware! { "hello from foo" };
 
     route_store.add_route(Method::Get, "/file/:format/:file", handler);
@@ -276,7 +276,7 @@ fn params_lifetime() {
 fn regex_path() {
     use regex::Regex;
 
-    let route_store = &mut Router::new();
+    let route_store = &mut Router::<()>::new();
 
     let regex = Regex::new("/(foo|bar)").unwrap();
     route_store.add_route(Method::Get, regex, middleware! { "hello from foo" });
@@ -298,7 +298,7 @@ fn regex_path() {
 fn regex_path_named() {
     use regex::Regex;
 
-    let route_store = &mut Router::new();
+    let route_store = &mut Router::<()>::new();
 
     let regex = Regex::new("/(?P<a>foo|bar)/b").unwrap();
     route_store.add_route(Method::Get, regex, middleware! { "hello from foo" });
@@ -323,7 +323,7 @@ fn regex_path_named() {
 fn ignores_querystring() {
     use regex::Regex;
 
-    let route_store = &mut Router::new();
+    let route_store = &mut Router::<()>::new();
 
     let regex = Regex::new("/(?P<a>foo|bar)/b").unwrap();
     route_store.add_route(Method::Get, regex, middleware! { "hello from foo" });

--- a/src/server.rs
+++ b/src/server.rs
@@ -9,32 +9,38 @@ use middleware::MiddlewareStack;
 use request;
 use response;
 
-pub struct Server {
-    middleware_stack: MiddlewareStack,
-    templates: response::TemplateCache
+pub struct Server<D> {
+    middleware_stack: MiddlewareStack<D>,
+    templates: response::TemplateCache,
+    shared_data: D,
 }
 
 // FIXME: Any better coherence solutions?
-struct ArcServer(Arc<Server>);
+struct ArcServer<D>(Arc<Server<D>>);
 
-impl Handler for ArcServer {
+impl<D: Sync + Send + 'static> Handler for ArcServer<D> {
     fn handle<'a, 'k>(&'a self, req: Request<'a, 'k>, res: Response<'a>) {
-        let req: Request<'a, 'k> = req;
-        let nickel_req = request::Request::from_internal(req);
-        let nickel_res = response::Response::from_internal(res, &self.0.templates);
+        let nickel_req = request::Request::from_internal(req,
+                                                         &self.0.shared_data);
+
+        let nickel_res = response::Response::from_internal(res,
+                                                           &self.0.templates,
+                                                           &self.0.shared_data);
+
         self.0.middleware_stack.invoke(nickel_req, nickel_res);
     }
 }
 
-impl Server {
-    pub fn new(middleware_stack: MiddlewareStack) -> Server {
+impl<D: Sync + Send + 'static> Server<D> {
+    pub fn new(middleware_stack: MiddlewareStack<D>, data: D) -> Server<D> {
         Server {
             middleware_stack: middleware_stack,
-            templates: RwLock::new(HashMap::new())
+            templates: RwLock::new(HashMap::new()),
+            shared_data: data
         }
     }
 
-    pub fn serve<T: ToSocketAddrs>(self, addr: T) -> HttpResult<Listening> {
+    pub fn serve<A: ToSocketAddrs>(self, addr: A) -> HttpResult<Listening> {
         let arc = ArcServer(Arc::new(self));
         let server = try!(HyperServer::http(addr));
         server.handle(arc)

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,0 +1,138 @@
+use {Request, Response, Cookies};
+use cookie::Cookie;
+use plugin::{Plugin, Pluggable};
+use typemap::Key;
+use std::marker::PhantomData;
+use std::any::Any;
+use time::{Timespec, Duration, self};
+use serialize::{Encodable, Decodable, json};
+use byteorder::{ByteOrder, BigEndian};
+use std::error::Error;
+use std::str;
+use std::fmt::Debug;
+
+static COOKIE_KEY : &'static str = "__SESSION";
+
+pub trait SessionStore {
+    type Store: Encodable + Decodable + Default + Debug;
+
+    fn timeout() -> Duration { Duration::minutes(60) }
+}
+
+// Plugin boilerplate
+pub struct SessionPlugin<T: 'static + Any>(PhantomData<T>);
+impl<T: 'static + Any> Key for SessionPlugin<T> { type Value = Option<T>; }
+
+impl<'mw, D, T> Plugin<Response<'mw, D>> for SessionPlugin<T>
+where Response<'mw, D> : Cookies,
+      T: 'static + Any + Encodable + Decodable + Default + Debug,
+      D: SessionStore<Store=T> {
+    type Error = ();
+
+    fn eval(response: &mut Response<'mw, D>) -> Result<Option<T>, ()> {
+        // Ensure our dependencies register their on_send
+        // FIXME: would be nice if this was more robust, but at least for now
+        // this minimizes the 'bug potential' to the library author rather than
+        // the library user.
+        let _ = response.cookies_mut().encrypted();
+
+        // Schedule the session to be written when headers are being sent
+        response.on_send(|response| {
+            let encoded = {
+                // This should only ever get called after an initial setup, so these
+                // unwraps should be fine!
+                let session = response.get_mut::<SessionPlugin<D::Store>>()
+                                      .unwrap();
+
+                // Todo: track when a write has occurred and only create the cookie in
+                // that case
+                encode_data(session.as_ref().unwrap())
+            };
+
+            let jar = response.cookies_mut().encrypted();
+            let mut cookie = Cookie::new(COOKIE_KEY.into(), encoded);
+            cookie.httponly = true;
+            jar.add(cookie);
+        });
+
+        Ok(None)
+    }
+}
+
+fn decode_data<T: Decodable + Default>(raw: &str, timeout: Duration) -> Result<T, Box<Error + Send + Sync>> {
+    use serialize::base64::FromBase64;
+
+    let timestamp_and_plaintext = try!(raw.from_base64());
+
+    let len = timestamp_and_plaintext.len();
+    let (plaintext, timestamp) = timestamp_and_plaintext.split_at(len - 8);
+
+    let timestamp = BigEndian::read_i64(timestamp);
+    let plaintext = try!(str::from_utf8(plaintext));
+    let timestamp = Timespec::new(timestamp, 0);
+
+    if timestamp + timeout > time::now().to_timespec() {
+        let decoded = try!(json::decode(plaintext));
+        Ok(decoded)
+    } else {
+        // Reset the session, not an error
+        Ok(T::default())
+    }
+}
+
+fn encode_data<T: Encodable + Debug>(data: &T) -> String {
+    use serialize::base64::{ToBase64, STANDARD};
+
+    // TODO: log if this fails
+    let json = match json::encode(data) {
+        Ok(json) => json,
+        Err(e) => {
+            println!("[Session] Failed to encode '{:?}' as json: {:?}", data, e);
+            return "".into()
+        },
+    };
+
+    let mut raw = json.into_bytes();
+
+    let mut timestamp = [0u8; 8];
+    BigEndian::write_i64(&mut timestamp, time::now().to_timespec().sec);
+    raw.extend(timestamp.iter().cloned());
+
+    raw.to_base64(STANDARD)
+}
+
+pub trait Session<D> where D: SessionStore {
+    /// Provides access to a mutable Session.
+    fn get_mut<'a>(&mut Request<D>, &'a mut Response<D>) -> &'a mut D::Store;
+}
+
+pub struct CookieSession;
+
+impl<D> Session<D> for CookieSession
+where for <'mw, 'conn> Request<'mw, 'conn, D> : Cookies,
+      for <'mw> Response<'mw, D> : Cookies,
+      D: SessionStore,
+      D::Store : 'static + Any + Encodable + Decodable + Default + Debug {
+    fn get_mut<'a>(req: &mut Request<D>, res: &'a mut Response<D>) -> &'a mut D::Store {
+        let cached_session = res.get_mut::<SessionPlugin<D::Store>>().unwrap();
+        if let Some(ref mut session) = *cached_session {
+            return session
+        }
+
+        let jar = req.cookies().encrypted();
+        let data = jar.find(COOKIE_KEY).and_then(|cookie| {
+            let timeout = <D as SessionStore>::timeout();
+            match decode_data(&*cookie.value, timeout) {
+                Ok(data) => Some(data),
+                Err(e) => {
+                    println!("Error parsing session: {:?}", e);
+                    None
+                }
+            }
+        });
+
+        // Any error resets the session
+        *cached_session = data.or_else(|| Some(<D::Store>::default()));
+        cached_session.as_mut().unwrap()
+    }
+}

--- a/tests/cfail.rs
+++ b/tests/cfail.rs
@@ -12,6 +12,10 @@ fn run_mode(mode: &'static str) {
     config.mode = cfg_mode;
     config.src_base = format!("tests/{}", mode).into();
 
+    if cfg!(not(feature = "secure_cookies")) {
+        config.filter = Some("inference".into());
+    }
+
     compiletest::run_tests(&config);
 }
 

--- a/tests/compile-fail/inference_fully_hinted.rs
+++ b/tests/compile-fail/inference_fully_hinted.rs
@@ -8,11 +8,11 @@ use nickel::{Nickel, HttpRouter, Request, Response};
 fn main() {
     let mut server = Nickel::new();
 
-    server.utilize(|_: &mut Request, res: Response| res.send("Hello World!"));
-    //~^ ERROR type mismatch resolving `for<'r,'b,'a> <[closure tests/com
+    server.utilize(|_: &mut Request<()>, res: Response<()>| res.send("Hello World!"));
+    //~^ ERROR type mismatch resolving `for<'
 
-    server.get("**", |_: &mut Request, res: Response| res.send("Hello World!"));
-    //~^ ERROR type mismatch resolving `for<'r,'b,'a> <[closure tests/com
+    server.get("**", |_: &mut Request<()>, res: Response<()>| res.send("Hello World!"));
+    //~^ ERROR type mismatch resolving `for<'
 
     server.listen("127.0.0.1:6767");
 }

--- a/tests/compile-fail/inference_no_hints.rs
+++ b/tests/compile-fail/inference_no_hints.rs
@@ -9,14 +9,14 @@ fn main() {
     let mut server = Nickel::new();
 
     server.utilize(|_, res| res.send("Hello World!"));
-    //~^ ERROR type mismatch resolving `for<'r,'b,'a> <[closure tests/compile-fail
+    //~^ ERROR type mismatch resolving `for<'
     //~^^ ERROR the type of this value must be known in this context
-    //~^^^ ERROR type mismatch: the type `[closure tests/compile
+    //~^^^ ERROR type mismatch: the type `[closure@tests/compile
 
     server.get("**", |_, res| res.send("Hello World!"));
-    //~^ ERROR type mismatch resolving `for<'r,'b,'a> <[closure tests/compile-fail
+    //~^ ERROR type mismatch resolving `for<'
     //~^^ ERROR the type of this value must be known in this context
-    //~^^^ ERROR type mismatch: the type `[closure tests/compile
+    //~^^^ ERROR type mismatch: the type `[closure@tests/compile
 
     server.listen("127.0.0.1:6767");
 }

--- a/tests/compile-fail/inference_request_hinted.rs
+++ b/tests/compile-fail/inference_request_hinted.rs
@@ -9,13 +9,13 @@ fn main() {
     let mut server = Nickel::new();
 
     // Request hinted
-    server.utilize(|_: &mut Request, res| res.send("Hello World!"));
+    server.utilize(|_: &mut Request<()>, res| res.send("Hello World!"));
     //~^ ERROR the type of this value must be known in this context
-    //~^^ ERROR type mismatch resolving `for<'r,'b,'a>
+    //~^^ ERROR type mismatch resolving `for<'
 
-    server.get("**", |_: &mut Request, res| res.send("Hello World!"));
+    server.get("**", |_: &mut Request<()>, res| res.send("Hello World!"));
     //~^ ERROR the type of this value must be known in this context
-    //~^^ ERROR type mismatch resolving `for<'r,'b,'a>
+    //~^^ ERROR type mismatch resolving `for<'
 
     server.listen("127.0.0.1:6767");
 }

--- a/tests/compile-fail/inference_response_hinted.rs
+++ b/tests/compile-fail/inference_response_hinted.rs
@@ -8,13 +8,13 @@ use nickel::{Nickel, HttpRouter, Request, Response};
 fn main() {
     let mut server = Nickel::new();
 
-    server.utilize(|_, res: Response| res.send("Hello World!"));
-    //~^ ERROR type mismatch resolving `for<'r,'b,'a> <[closure tests/compile-fail
-    //~^^ ERROR type mismatch: the type `[closure tests/compile-fail
+    server.utilize(|_, res: Response<()>| res.send("Hello World!"));
+    //~^ ERROR type mismatch resolving `for<'
+    //~^^ ERROR type mismatch: the type `[closure@tests/compile-fail
 
-    server.get("**", |_, res: Response| res.send("Hello World!"));
-    //~^ ERROR type mismatch resolving `for<'r,'b,'a> <[closure tests/compile-fail
-    //~^^ ERROR type mismatch: the type `[closure tests/compile-fail
+    server.get("**", |_, res: Response<()>| res.send("Hello World!"));
+    //~^ ERROR type mismatch resolving `for<'
+    //~^^ ERROR type mismatch: the type `[closure@tests/compile-fail
 
     server.listen("127.0.0.1:6767");
 }

--- a/tests/compile-fail/unmet_data_requirement.rs
+++ b/tests/compile-fail/unmet_data_requirement.rs
@@ -1,0 +1,41 @@
+#[macro_use] extern crate nickel;
+extern crate cookie;
+
+use nickel::{Nickel, HttpRouter, Cookies, QueryString};
+use nickel::cookies;
+use cookie::Cookie;
+
+struct Data {
+    secret_key: cookies::SecretKey
+}
+
+fn main() {
+    let data = Data { secret_key: cookies::SecretKey([0; 32]) };
+    let mut server = Nickel::with_data(data);
+
+    // Try curl -b MyCookie=bar localhost:6767
+    server.get("/", middleware! { |req|
+        let cookie = req.cookies().find("MyCookie");
+        //~^ ERROR: the trait `core::convert::AsRef<nickel::cookies::SecretKey>` is not implemented for the type `Data`
+        format!("MyCookie={:?}", cookie.map(|c| c.value))
+    });
+
+    // Note: Don't use get for login in real applications ;)
+    // Try http://localhost:6767/login?name=foo
+    server.get("/login", middleware! { |req, mut res|
+        let jar = res.cookies_mut()
+        //~^ ERROR: the trait `core::convert::AsRef<nickel::cookies::SecretKey>` is not implemented for the type `Data`
+                     // long life cookies!
+                     .permanent();
+
+        let name = req.query().get("name")
+                              .unwrap_or("default_name");
+        let cookie = Cookie::new("MyCookie".to_owned(),
+                                 name.to_owned());
+        jar.add(cookie);
+
+        "Cookie set!"
+    });
+
+    server.listen("127.0.0.1:6767");
+}


### PR DESCRIPTION
After some back and forth and testing with @cburgdorf's project, this takes an alternative approach from #246 which should cause less dancing with borrowck while maintaining most of the functionality.

I also added some cargo `features` for the crate, which if you check `cookies_example` allows using non-encrypted cookies without any of the setup involving the datatype. It also provides a *decent* default implementation for the `KeyProvider` which will hopefully mean people aren't incentivized to use zerod-keys for convenience when they do want encryption/sessions.

I'm a little bit worried about the api for the cookies, as I did waste a bit of time when I was trying to `find` a cookie from within the `res.cookies()`  and never getting a result (as I should have been checking the inbound cookies on `req`). I had considered blocking the `find` functionality for the `Response`'s `CookieJar`, but I can imagine that it may be a requirement for some middleware to re-write an outgoing cookie for some reason. Perhaps `res.cookies_out()` and `req.cookies_in()`? It would really have been nice if `find` just fell through from the outgoing cookies to the incoming (new cookies override) but that might be unexpected by users. 