### PR TITLE
feat(pencil): allow Hyper SSL feature to be disabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ readme = "README.md"
 keywords = ["nickel", "server", "web", "express"]
 
 [features]
+default = ["ssl"]
 unstable = ["hyper/nightly", "compiletest_rs"]
+ssl = ["hyper/ssl"]
 
 [dependencies]
 url = "*"
@@ -23,11 +25,14 @@ plugin = "*"
 regex = "*"
 rustc-serialize = "*"
 log = "*"
-hyper = "=0.6"
 groupable = "*"
 mustache = "*"
 lazy_static = "*"
 modifier = "*"
+
+[dependencies.hyper]
+version = "=0.6"
+default-features = false
 
 [dependencies.compiletest_rs]
 version = "*"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ authors = ["yourname"]
 
 [dependencies.nickel]
 version = "*"
+# If you are on Windows, you may disable SSL by uncommenting
+# the line below
+# default-features = false
+
 # If you are using the 'nightly' rust channel you can uncomment
 # the line below to activate unstable features
 # features = ["unstable"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ extern crate modifier;
 #[macro_use] extern crate lazy_static;
 
 pub use nickel::Nickel;
+pub use nickel::Options;
 pub use request::Request;
 pub use response::Response;
 pub use middleware::{Action, Continue, Halt, Middleware, ErrorHandler, MiddlewareResult};


### PR DESCRIPTION
In order for Windows users to be able to use nickel without having to install MinGW and OpenSSL, I'm making Hyper's SSL feature optional. It can be disabled by adding 'default-features = false' in your [dependencies.nickel]. This is related to the issue #274 that I reported yesterday.