### PR TITLE
feat(ssl): make Hyper's SSL feature optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["nickel", "server", "web", "express"]
 
 [features]
 unstable = ["hyper/nightly", "compiletest_rs"]
+ssl = ["hyper/ssl"]
 
 [dependencies]
 url = "*"
@@ -23,11 +24,14 @@ plugin = "*"
 regex = "*"
 rustc-serialize = "*"
 log = "*"
-hyper = "=0.6"
 groupable = "*"
 mustache = "*"
 lazy_static = "*"
 modifier = "*"
+
+[dependencies.hyper]
+version = "=0.6"
+default-features = false
 
 [dependencies.compiletest_rs]
 version = "*"


### PR DESCRIPTION
I'm sorry for the mess earlier. Everything has been cleaned up now.

In order for Windows users to be able to use nickel without having to install MinGW and OpenSSL, I'm making Hyper's SSL feature optional. It can be disabled by adding 'default-features = false' in your [dependencies.nickel]. This is related to the issue #274 that I reported yesterday.