### PR TITLE
feat(nickel): add options to Nickel, allowing the user to disable the messages output on listen

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ extern crate modifier;
 #[macro_use] extern crate lazy_static;
 
 pub use nickel::Nickel;
+pub use nickel::Options;
 pub use request::Request;
 pub use response::Response;
 pub use middleware::{Action, Continue, Halt, Middleware, ErrorHandler, MiddlewareResult};


### PR DESCRIPTION
This is in relation to the pull request #124 - it adds two methods to Nickel - a static default_options, and set_options. The only option available is output_on_listen, which when disabled, won't display "Listening on x.x.x.x:xxxx/Press Ctrl+C to shutdown the server" (it is enabled by default, which is the current behavior). This could be extended later on for whatever other options.