### PR TITLE
feat(server): shared data between requests and plugins for Response

### DIFF
--- a/examples/macro_example.rs
+++ b/examples/macro_example.rs
@@ -19,13 +19,13 @@ struct Person {
 }
 
 //this is an example middleware function that just logs each request
-fn logger<'a>(request: &mut Request, response: Response<'a>) -> MiddlewareResult<'a> {
+fn logger<'a, D>(request: &mut Request<D>, response: Response<'a, D>) -> MiddlewareResult<'a, D> {
     println!("logging request: {:?}", request.origin.uri);
     Ok(Continue(response))
 }
 
 //this is how to overwrite the default error handler to handle 404 cases with a custom view
-fn custom_404<'a>(err: &mut NickelError, _req: &mut Request) -> Action {
+fn custom_404<'a, D>(err: &mut NickelError<D>, _req: &mut Request<D>) -> Action {
     if let Some(ref mut res) = err.stream {
         if res.status() == NotFound {
             let _ = res.write_all(b"<h1>Call the police!</h1>");
@@ -122,7 +122,7 @@ fn main() {
     ));
 
     // issue #20178
-    let custom_handler: fn(&mut NickelError, &mut Request) -> Action = custom_404;
+    let custom_handler: fn(&mut NickelError<()>, &mut Request<()>) -> Action = custom_404;
 
     server.handle_error(custom_handler);
 

--- a/src/default_error_handler.rs
+++ b/src/default_error_handler.rs
@@ -7,8 +7,8 @@ use std::io::Write;
 #[derive(Clone, Copy)]
 pub struct DefaultErrorHandler;
 
-impl ErrorHandler for DefaultErrorHandler {
-    fn handle_error(&self, err: &mut NickelError, _req: &mut Request) -> Action {
+impl<D> ErrorHandler<D> for DefaultErrorHandler {
+    fn handle_error(&self, err: &mut NickelError<D>, _req: &mut Request<D>) -> Action {
         if let Some(ref mut res) = err.stream {
             let msg : &[u8] = match res.status() {
                 NotFound => b"Not Found",

--- a/src/favicon_handler.rs
+++ b/src/favicon_handler.rs
@@ -6,7 +6,6 @@ use hyper::uri::RequestUri::AbsolutePath;
 use hyper::method::Method::{Get, Head, Options};
 use hyper::status::StatusCode;
 use hyper::header;
-use hyper::net;
 
 use request::Request;
 use response::Response;
@@ -18,9 +17,9 @@ pub struct FaviconHandler {
     icon_path: PathBuf, // Is it useful to log where in-memory favicon came from every request?
 }
 
-impl Middleware for FaviconHandler {
-    fn invoke<'a, 'server>(&'a self, req: &mut Request<'a, 'server>, res: Response<'a, net::Fresh>)
-            -> MiddlewareResult<'a> {
+impl<D> Middleware<D> for FaviconHandler {
+    fn invoke<'a, 'server>(&'a self, req: &mut Request<'a, 'server, D>, res: Response<'a, D>)
+            -> MiddlewareResult<'a, D> {
         if FaviconHandler::is_favicon_request(req) {
             self.handle_request(req, res)
         } else {
@@ -53,14 +52,14 @@ impl FaviconHandler {
     }
 
     #[inline]
-    pub fn is_favicon_request(req: &Request) -> bool {
+    pub fn is_favicon_request<D>(req: &Request<D>) -> bool {
         match req.origin.uri {
             AbsolutePath(ref path) => &**path == "/favicon.ico",
             _                      => false
         }
     }
 
-    pub fn handle_request<'a>(&self, req: &Request, mut res: Response<'a>) -> MiddlewareResult<'a> {
+    pub fn handle_request<'a, D>(&self, req: &Request<D>, mut res: Response<'a, D>) -> MiddlewareResult<'a, D> {
         match req.origin.method {
             Get | Head => {
                 self.send_favicon(req, res)
@@ -78,7 +77,7 @@ impl FaviconHandler {
         }
     }
 
-    pub fn send_favicon<'a, 'server>(&self, req: &Request, mut res: Response<'a>) -> MiddlewareResult<'a> {
+    pub fn send_favicon<'a, D>(&self, req: &Request<D>, mut res: Response<'a, D>) -> MiddlewareResult<'a, D> {
         debug!("{:?} {:?}", req.origin.method, self.icon_path.display());
         res.set(MediaType::Ico);
         res.send(&*self.icon)

--- a/src/json_body_parser.rs
+++ b/src/json_body_parser.rs
@@ -8,10 +8,11 @@ use std::io::{Read, ErrorKind};
 // Plugin boilerplate
 struct JsonBodyParser;
 impl Key for JsonBodyParser { type Value = String; }
-impl<'mw, 'conn> Plugin<Request<'mw, 'conn>> for JsonBodyParser {
+
+impl<'mw, 'conn, D> Plugin<Request<'mw, 'conn, D>> for JsonBodyParser {
     type Error = io::Error;
 
-    fn eval(req: &mut Request) -> Result<String, io::Error> {
+    fn eval(req: &mut Request<D>) -> Result<String, io::Error> {
         let mut s = String::new();
         try!(req.origin.read_to_string(&mut s));
         Ok(s)
@@ -22,7 +23,7 @@ pub trait JsonBody {
     fn json_as<T: Decodable>(&mut self) -> Result<T, io::Error>;
 }
 
-impl<'mw, 'conn> JsonBody for Request<'mw, 'conn> {
+impl<'mw, 'conn, D> JsonBody for Request<'mw, 'conn, D> {
     fn json_as<T: Decodable>(&mut self) -> Result<T, io::Error> {
         self.get_ref::<JsonBodyParser>().and_then(|parsed|
             json::decode::<T>(&*parsed).map_err(|err|

--- a/src/macros/middleware.rs
+++ b/src/macros/middleware.rs
@@ -38,18 +38,18 @@ macro_rules! _middleware_inner {
         use $crate::{MiddlewareResult,Responder, Response, Request};
 
         #[inline(always)]
-        fn restrict<'mw, R: Responder>(r: R, res: Response<'mw>)
-                -> MiddlewareResult<'mw> {
+        fn restrict<'mw, D, R: Responder<D>>(r: R, res: Response<'mw, D>)
+                -> MiddlewareResult<'mw, D> {
             res.send(r)
         }
 
         // Inference fails due to thinking it's a (&Request, Response) with
         // different mutability requirements
         #[inline(always)]
-        fn restrict_closure<F>(f: F) -> F
+        fn restrict_closure<F, D>(f: F) -> F
             where F: for<'r, 'mw, 'conn>
-                        Fn(&'r mut Request<'mw, 'conn>, Response<'mw>)
-                            -> MiddlewareResult<'mw> + Send + Sync { f }
+                        Fn(&'r mut Request<'mw, 'conn, D>, Response<'mw, D>)
+                            -> MiddlewareResult<'mw, D> + Send + Sync { f }
 
         restrict_closure(move |as_pat!($req), $res_binding| {
             restrict(as_block!({$($b)+}), $res)

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -32,7 +32,7 @@ pub trait ErrorHandler<D>: Send + 'static + Sync {
     fn handle_error(&self, &mut NickelError<D>, &mut Request<D>) -> Action;
 }
 
-impl<D> ErrorHandler<D> for fn(&mut NickelError<D>, &mut Request<D>) -> Action {
+impl<D: 'static> ErrorHandler<D> for fn(&mut NickelError<D>, &mut Request<D>) -> Action {
     fn handle_error(&self, err: &mut NickelError<D>, req: &mut Request<D>) -> Action {
         (*self)(err, req)
     }
@@ -43,7 +43,7 @@ pub struct MiddlewareStack<D=()> {
     error_handlers: Vec<Box<ErrorHandler<D> + Send + Sync>>
 }
 
-impl<D> MiddlewareStack<D> {
+impl<D: 'static> MiddlewareStack<D> {
     pub fn add_middleware<T: Middleware<D>> (&mut self, handler: T) {
         self.handlers.push(Box::new(handler));
     }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -5,9 +5,9 @@ use hyper::net;
 
 pub use self::Action::{Continue, Halt};
 
-pub type MiddlewareResult<'mw> = Result<Action<Response<'mw, net::Fresh>,
-                                              Response<'mw, net::Streaming>>,
-                                        NickelError<'mw>>;
+pub type MiddlewareResult<'mw, D> = Result<Action<Response<'mw, D, net::Fresh>,
+                                              Response<'mw, D, net::Streaming>>,
+                                        NickelError<'mw, D>>;
 
 pub enum Action<T=(), U=()> {
     Continue(T),
@@ -16,43 +16,43 @@ pub enum Action<T=(), U=()> {
 
 // the usage of + Send is weird here because what we really want is + Static
 // but that's not possible as of today. We have to use + Send for now.
-pub trait Middleware: Send + 'static + Sync {
-    fn invoke<'mw, 'conn>(&'mw self, _req: &mut Request<'mw, 'conn>, res: Response<'mw, net::Fresh>) -> MiddlewareResult<'mw> {
+pub trait Middleware<D>: Send + 'static + Sync {
+    fn invoke<'mw, 'conn>(&'mw self, _req: &mut Request<'mw, 'conn, D>, res: Response<'mw, D, net::Fresh>) -> MiddlewareResult<'mw, D> {
         Ok(Continue(res))
     }
 }
 
-impl<T> Middleware for T where T: for<'r, 'mw, 'conn> Fn(&'r mut Request<'mw, 'conn>, Response<'mw>) -> MiddlewareResult<'mw> + Send + Sync + 'static {
-    fn invoke<'mw, 'conn>(&'mw self, req: &mut Request<'mw, 'conn>, res: Response<'mw>) -> MiddlewareResult<'mw> {
+impl<T, D> Middleware<D> for T where T: for<'r, 'mw, 'conn> Fn(&'r mut Request<'mw, 'conn, D>, Response<'mw, D>) -> MiddlewareResult<'mw, D> + Send + Sync + 'static {
+    fn invoke<'mw, 'conn>(&'mw self, req: &mut Request<'mw, 'conn, D>, res: Response<'mw, D>) -> MiddlewareResult<'mw, D> {
         (*self)(req, res)
     }
 }
 
-pub trait ErrorHandler: Send + 'static + Sync {
-    fn handle_error(&self, &mut NickelError, &mut Request) -> Action;
+pub trait ErrorHandler<D>: Send + 'static + Sync {
+    fn handle_error(&self, &mut NickelError<D>, &mut Request<D>) -> Action;
 }
 
-impl ErrorHandler for fn(&mut NickelError, &mut Request) -> Action {
-    fn handle_error(&self, err: &mut NickelError, req: &mut Request) -> Action {
+impl<D> ErrorHandler<D> for fn(&mut NickelError<D>, &mut Request<D>) -> Action {
+    fn handle_error(&self, err: &mut NickelError<D>, req: &mut Request<D>) -> Action {
         (*self)(err, req)
     }
 }
 
-pub struct MiddlewareStack {
-    handlers: Vec<Box<Middleware + Send + Sync>>,
-    error_handlers: Vec<Box<ErrorHandler + Send + Sync>>
+pub struct MiddlewareStack<D=()> {
+    handlers: Vec<Box<Middleware<D> + Send + Sync>>,
+    error_handlers: Vec<Box<ErrorHandler<D> + Send + Sync>>
 }
 
-impl MiddlewareStack {
-    pub fn add_middleware<T: Middleware> (&mut self, handler: T) {
+impl<D> MiddlewareStack<D> {
+    pub fn add_middleware<T: Middleware<D>> (&mut self, handler: T) {
         self.handlers.push(Box::new(handler));
     }
 
-    pub fn add_error_handler<T: ErrorHandler> (&mut self, handler: T) {
+    pub fn add_error_handler<T: ErrorHandler<D>> (&mut self, handler: T) {
         self.error_handlers.push(Box::new(handler));
     }
 
-    pub fn invoke<'mw, 'conn>(&'mw self, mut req: Request<'mw, 'conn>, mut res: Response<'mw>) {
+    pub fn invoke<'mw, 'conn>(&'mw self, mut req: Request<'mw, 'conn, D>, mut res: Response<'mw, D>) {
         for handler in self.handlers.iter() {
             match handler.invoke(&mut req, res) {
                 Ok(Halt(res)) => {
@@ -92,7 +92,7 @@ impl MiddlewareStack {
         }
     }
 
-    pub fn new () -> MiddlewareStack {
+    pub fn new () -> MiddlewareStack<D> {
         MiddlewareStack{
             handlers: Vec::new(),
             error_handlers: Vec::new()

--- a/src/nickel.rs
+++ b/src/nickel.rs
@@ -10,12 +10,13 @@ use default_error_handler::DefaultErrorHandler;
 
 /// Nickel is the application object. It's the surface that
 /// holds all public APIs.
-pub struct Nickel{
-    middleware_stack: MiddlewareStack,
+pub struct Nickel<D: Sync + Send + 'static = ()> {
+    middleware_stack: MiddlewareStack<D>,
+    data: D
 }
 
-impl HttpRouter for Nickel {
-    fn add_route<M: Into<Matcher>, H: Middleware>(&mut self, method: Method, matcher: M, handler: H) -> &mut Self {
+impl<D: Sync + Send + 'static> HttpRouter<D> for Nickel<D> {
+    fn add_route<M: Into<Matcher>, H: Middleware<D>>(&mut self, method: Method, matcher: M, handler: H) -> &mut Self {
         let mut router = Router::new();
         router.add_route(method, matcher, handler);
         self.utilize(router);
@@ -23,9 +24,16 @@ impl HttpRouter for Nickel {
     }
 }
 
-impl Nickel {
+impl Nickel<()> {
     /// Creates an instance of Nickel with default error handling.
-    pub fn new() -> Nickel {
+    pub fn new() -> Nickel<()> {
+        Nickel::with_data(())
+    }
+}
+
+impl<D: Sync + Send + 'static> Nickel<D> {
+    /// Creates an instance of Nickel with default error handling and custom data.
+    pub fn with_data(data: D) -> Nickel<D> {
         let mut middleware_stack = MiddlewareStack::new();
 
         // Hook up the default error handler by default. Users are
@@ -33,7 +41,10 @@ impl Nickel {
         // they don't like the default behaviour.
         middleware_stack.add_error_handler(DefaultErrorHandler);
 
-        Nickel { middleware_stack: middleware_stack }
+        Nickel {
+            middleware_stack: middleware_stack,
+            data: data
+        }
     }
 
     /// Registers a middleware handler which will be invoked among other middleware
@@ -57,7 +68,7 @@ impl Nickel {
     /// });
     /// # }
     /// ```
-    pub fn utilize<T: Middleware>(&mut self, handler: T){
+    pub fn utilize<T: Middleware<D>>(&mut self, handler: T){
         self.middleware_stack.add_middleware(handler);
     }
 
@@ -77,7 +88,7 @@ impl Nickel {
     /// use nickel::{NickelError, Action};
     /// use nickel::status::StatusCode::NotFound;
     ///
-    /// fn error_handler(err: &mut NickelError, _req: &mut Request) -> Action {
+    /// fn error_handler<D>(err: &mut NickelError<D>, _req: &mut Request<D>) -> Action {
     ///    if let Some(ref mut res) = err.stream {
     ///        if res.status() == NotFound {
     ///            let _ = res.write_all(b"<h1>Call the police!</h1>");
@@ -90,12 +101,12 @@ impl Nickel {
     ///
     /// let mut server = Nickel::new();
     ///
-    /// let ehandler: fn(&mut NickelError, &mut Request) -> Action = error_handler;
+    /// let ehandler: fn(&mut NickelError<()>, &mut Request<()>) -> Action = error_handler;
     ///
     /// server.handle_error(ehandler)
     /// # }
     /// ```
-    pub fn handle_error<T: ErrorHandler>(&mut self, handler: T){
+    pub fn handle_error<T: ErrorHandler<D>>(&mut self, handler: T){
         self.middleware_stack.add_error_handler(handler);
     }
 
@@ -118,7 +129,7 @@ impl Nickel {
     ///     server.utilize(router);
     /// }
     /// ```
-    pub fn router() -> Router {
+    pub fn router() -> Router<D> {
         Router::new()
     }
 
@@ -140,7 +151,7 @@ impl Nickel {
             (StatusCode::NotFound, "File Not Found")
         });
 
-        let server = Server::new(self.middleware_stack);
+        let server = Server::new(self.middleware_stack, self.data);
         let listener = server.serve(addr).unwrap();
 
         println!("Listening on http://{}", listener.socket);

--- a/src/nickel_error.rs
+++ b/src/nickel_error.rs
@@ -7,12 +7,12 @@ use hyper::net::{Fresh, Streaming};
 
 /// NickelError is the basic error type for HTTP errors as well as user defined errors.
 /// One can pattern match against the `kind` property to handle the different cases.
-pub struct NickelError<'a> {
-    pub stream: Option<Response<'a, Streaming>>,
+pub struct NickelError<'a, D: 'a = ()> {
+    pub stream: Option<Response<'a, D, Streaming>>,
     pub message: Cow<'static, str>
 }
 
-impl<'a> NickelError<'a> {
+impl<'a, D> NickelError<'a, D> {
     /// Creates a new `NickelError` instance.
     ///
     /// You should probably use `Response#error` in favor of this.
@@ -26,14 +26,14 @@ impl<'a> NickelError<'a> {
     /// use nickel::status::StatusCode;
     ///
     /// # #[allow(dead_code)]
-    /// fn handler<'a>(_: &mut Request, res: Response<'a>) -> MiddlewareResult<'a> {
+    /// fn handler<'a, D>(_: &mut Request<D>, res: Response<'a, D>) -> MiddlewareResult<'a, D> {
     ///     Err(NickelError::new(res, "Error Parsing JSON", StatusCode::BadRequest))
     /// }
     /// # }
     /// ```
-    pub fn new<T>(mut stream: Response<'a, Fresh>,
+    pub fn new<T>(mut stream: Response<'a, D, Fresh>,
                   message: T,
-                  status_code: StatusCode) -> NickelError<'a>
+                  status_code: StatusCode) -> NickelError<'a, D>
             where T: Into<Cow<'static, str>> {
         stream.set(status_code);
 
@@ -56,7 +56,7 @@ impl<'a> NickelError<'a> {
     ///
     /// This is considered `unsafe` as deadlock can occur if the `Response`
     /// does not have the underlying stream flushed when processing is finished.
-    pub unsafe fn without_response<T>(message: T) -> NickelError<'a>
+    pub unsafe fn without_response<T>(message: T) -> NickelError<'a, D>
             where T: Into<Cow<'static, str>> {
         NickelError {
             stream: None,
@@ -69,22 +69,22 @@ impl<'a> NickelError<'a> {
     }
 }
 
-impl<'a, T> From<(Response<'a>, (StatusCode, T))> for NickelError<'a>
+impl<'a, T, D> From<(Response<'a, D>, (StatusCode, T))> for NickelError<'a, D>
         where T: Into<Box<Error + 'static>> {
-    fn from((res, (errorcode, err)): (Response<'a>, (StatusCode, T))) -> NickelError<'a> {
+    fn from((res, (errorcode, err)): (Response<'a, D>, (StatusCode, T))) -> NickelError<'a, D> {
         let err = err.into();
         NickelError::new(res, err.description().to_string(), errorcode)
     }
 }
 
-impl<'a> From<(Response<'a>, String)> for NickelError<'a> {
-    fn from((res, msg): (Response<'a>, String)) -> NickelError<'a> {
+impl<'a, D> From<(Response<'a, D>, String)> for NickelError<'a, D> {
+    fn from((res, msg): (Response<'a, D>, String)) -> NickelError<'a, D> {
         NickelError::new(res, msg, StatusCode::InternalServerError)
     }
 }
 
-impl<'a> From<(Response<'a>, StatusCode)> for NickelError<'a> {
-    fn from((res, code): (Response<'a>, StatusCode)) -> NickelError<'a> {
+impl<'a, D> From<(Response<'a, D>, StatusCode)> for NickelError<'a, D> {
+    fn from((res, code): (Response<'a, D>, StatusCode)) -> NickelError<'a, D> {
         NickelError::new(res, "", code)
     }
 }

--- a/src/query_string.rs
+++ b/src/query_string.rs
@@ -33,10 +33,10 @@ impl Query {
 struct QueryStringParser;
 impl Key for QueryStringParser { type Value = Query; }
 
-impl<'mw, 'conn> Plugin<Request<'mw, 'conn>> for QueryStringParser {
+impl<'mw, 'conn, D> Plugin<Request<'mw, 'conn, D>> for QueryStringParser {
     type Error = ();
 
-    fn eval(req: &mut Request) -> Result<Query, ()> {
+    fn eval(req: &mut Request<D>) -> Result<Query, ()> {
         Ok(parse(&req.origin.uri))
     }
 }
@@ -46,7 +46,7 @@ pub trait QueryString {
     fn query(&mut self) -> &Query;
 }
 
-impl<'mw, 'conn> QueryString for Request<'mw, 'conn> {
+impl<'mw, 'conn, D> QueryString for Request<'mw, 'conn, D> {
     fn query(&mut self) -> &Query {
         self.get_ref::<QueryStringParser>()
             .ok()

--- a/src/request.rs
+++ b/src/request.rs
@@ -11,21 +11,25 @@ use hyper::uri::RequestUri::AbsolutePath;
 ///
 /// The lifetime `'server` represents the lifetime of data internal to
 /// the server. It is fixed and longer than `'mw`.
-pub struct Request<'mw, 'server: 'mw> {
+pub struct Request<'mw, 'server: 'mw, D: 'mw = ()> {
     ///the original `hyper::server::Request`
     pub origin: HyperRequest<'mw, 'server>,
     ///a `HashMap<String, String>` holding all params with names and values
-    pub route_result: Option<RouteResult<'mw>>,
+    pub route_result: Option<RouteResult<'mw, D>>,
 
-    map: TypeMap
+    map: TypeMap,
+
+    data: &'mw D,
 }
 
-impl<'mw, 'server> Request<'mw, 'server> {
-    pub fn from_internal(req: HyperRequest<'mw, 'server>) -> Request<'mw, 'server> {
+impl<'mw, 'server, D> Request<'mw, 'server, D> {
+    pub fn from_internal(req: HyperRequest<'mw, 'server>,
+                         data: &'mw D) -> Request<'mw, 'server, D> {
         Request {
             origin: req,
             route_result: None,
-            map: TypeMap::new()
+            map: TypeMap::new(),
+            data: data
         }
     }
 
@@ -39,9 +43,13 @@ impl<'mw, 'server> Request<'mw, 'server> {
             _ => None
         }
     }
+
+    pub fn server_data(&self) -> &D {
+        &self.data
+    }
 }
 
-impl<'mw, 'server> Extensible for Request<'mw, 'server> {
+impl<'mw, 'server, D> Extensible for Request<'mw, 'server, D> {
     fn extensions(&self) -> &TypeMap {
         &self.map
     }
@@ -51,4 +59,4 @@ impl<'mw, 'server> Extensible for Request<'mw, 'server> {
     }
 }
 
-impl<'mw, 'server> Pluggable for Request<'mw, 'server> {}
+impl<'mw, 'server, D> Pluggable for Request<'mw, 'server, D> {}

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,3 +1,4 @@
+use std::mem;
 use std::borrow::Cow;
 use std::sync::RwLock;
 use std::collections::HashMap;
@@ -19,6 +20,8 @@ use std::fs::File;
 use std::any::Any;
 use {NickelError, Halt, MiddlewareResult, Responder};
 use modifier::Modifier;
+use plugin::{Extensible, Pluggable};
+use typemap::TypeMap;
 
 pub type TemplateCache = RwLock<HashMap<String, Template>>;
 
@@ -28,6 +31,9 @@ pub struct Response<'a, D: 'a = (), T: 'static + Any = Fresh> {
     origin: HyperResponse<'a, T>,
     templates: &'a TemplateCache,
     data: &'a D,
+    map: TypeMap,
+    // This should be FnBox, but that's currently unstable
+    on_send: Vec<Box<FnMut(&mut Response<'a, D, Fresh>)>>
 }
 
 impl<'a, D> Response<'a, D, Fresh> {
@@ -38,7 +44,9 @@ impl<'a, D> Response<'a, D, Fresh> {
         Response {
             origin: response,
             templates: templates,
-            data: data
+            data: data,
+            map: TypeMap::new(),
+            on_send: vec![]
         }
     }
 
@@ -243,15 +251,25 @@ impl<'a, D> Response<'a, D, Fresh> {
     }
 
     pub fn start(mut self) -> Result<Response<'a, D, Streaming>, NickelError<'a, D>> {
+        let on_send = mem::replace(&mut self.on_send, vec![]);
+        for mut f in on_send.into_iter().rev() {
+            // TODO: Ensure `f` doesn't call on_send again
+            f(&mut self)
+        }
+
+        // Set fallback headers last after everything runs, if we did this before as an
+        // on_send then it would possibly set redundant things.
         self.set_fallback_headers();
 
-        let Response { origin, templates, data } = self;
+        let Response { origin, templates, data, map, on_send } = self;
         match origin.start() {
             Ok(origin) => {
                 Ok(Response {
                     origin: origin,
                     templates: templates,
-                    data: data
+                    data: data,
+                    map: map,
+                    on_send: on_send
                 })
             },
             Err(e) =>
@@ -263,6 +281,11 @@ impl<'a, D> Response<'a, D, Fresh> {
 
     pub fn server_data(&self) -> &D {
         &self.data
+    }
+
+    pub fn on_send<F>(&mut self, f: F)
+            where F: FnMut(&mut Response<'a, D, Fresh>) + 'static {
+        self.on_send.push(Box::new(f))
     }
 }
 
@@ -305,7 +328,23 @@ impl <'a, D, T: 'static + Any> Response<'a, D, T> {
     pub fn headers(&self) -> &Headers {
         self.origin.headers()
     }
+
+    pub fn data(&self) -> &D {
+        &self.data
+    }
 }
+
+impl<'a, D, T: 'static + Any> Extensible for Response<'a, D, T> {
+    fn extensions(&self) -> &TypeMap {
+        &self.map
+    }
+
+    fn extensions_mut(&mut self) -> &mut TypeMap {
+        &mut self.map
+    }
+}
+
+impl<'a, D, T: 'static + Any> Pluggable for Response<'a, D, T> {}
 
 fn mime_from_filename<P: AsRef<Path>>(path: P) -> Option<MediaType> {
     path.as_ref()

--- a/src/router/http_router.rs
+++ b/src/router/http_router.rs
@@ -2,7 +2,7 @@ use hyper::method::Method;
 use middleware::Middleware;
 use router::Matcher;
 
-pub trait HttpRouter {
+pub trait HttpRouter<D> {
     /// Registers a handler to be used for a specified method.
     /// A handler can be anything implementing the `RequestHandler` trait.
     ///
@@ -36,7 +36,7 @@ pub trait HttpRouter {
     ///     server.add_route(Get, regex, middleware! { "Regex Get request! "});
     /// }
     /// ```
-    fn add_route<M: Into<Matcher>, H: Middleware>(&mut self, Method, M, H) -> &mut Self;
+    fn add_route<M: Into<Matcher>, H: Middleware<D>>(&mut self, Method, M, H) -> &mut Self;
 
     /// Registers a handler to be used for a specific GET request.
     /// Handlers are assigned to paths and paths are allowed to contain
@@ -121,42 +121,42 @@ pub trait HttpRouter {
     ///     server.utilize(router);
     /// }
     /// ```
-    fn get<M: Into<Matcher>, H: Middleware>(&mut self, matcher: M, handler: H) -> &mut Self {
+    fn get<M: Into<Matcher>, H: Middleware<D>>(&mut self, matcher: M, handler: H) -> &mut Self {
         self.add_route(Method::Get, matcher, handler)
     }
 
     /// Registers a handler to be used for a specific POST request.
     ///
     /// Take a look at `get(...)` for a more detailed description.
-    fn post<M: Into<Matcher>, H: Middleware>(&mut self, matcher: M, handler: H) -> &mut Self {
+    fn post<M: Into<Matcher>, H: Middleware<D>>(&mut self, matcher: M, handler: H) -> &mut Self {
         self.add_route(Method::Post, matcher, handler)
     }
 
     /// Registers a handler to be used for a specific PUT request.
     ///
     /// Take a look at `get(...)` for a more detailed description.
-    fn put<M: Into<Matcher>, H: Middleware>(&mut self, matcher: M, handler: H) -> &mut Self {
+    fn put<M: Into<Matcher>, H: Middleware<D>>(&mut self, matcher: M, handler: H) -> &mut Self {
         self.add_route(Method::Put, matcher, handler)
     }
 
     /// Registers a handler to be used for a specific DELETE request.
     ///
     /// Take a look at `get(...)` for a more detailed description.
-    fn delete<M: Into<Matcher>, H: Middleware>(&mut self, matcher: M, handler: H) -> &mut Self {
+    fn delete<M: Into<Matcher>, H: Middleware<D>>(&mut self, matcher: M, handler: H) -> &mut Self {
         self.add_route(Method::Delete, matcher, handler)
     }
 
     /// Registers a handler to be used for a specific OPTIONS request.
     ///
     /// Take a look at `get(...)` for a more detailed description.
-    fn options<M: Into<Matcher>, H: Middleware>(&mut self, matcher: M, handler: H) -> &mut Self {
+    fn options<M: Into<Matcher>, H: Middleware<D>>(&mut self, matcher: M, handler: H) -> &mut Self {
         self.add_route(Method::Options, matcher, handler)
     }
 
     /// Registers a handler to be used for a specific PATCH request.
     ///
     /// Take a look at `get(...)` for a more detailed description.
-    fn patch<M: Into<Matcher>, H: Middleware>(&mut self, matcher: M, handler: H) -> &mut Self {
+    fn patch<M: Into<Matcher>, H: Middleware<D>>(&mut self, matcher: M, handler: H) -> &mut Self {
         self.add_route(Method::Patch, matcher, handler)
     }
 }

--- a/src/router/router.rs
+++ b/src/router/router.rs
@@ -10,9 +10,9 @@ use router::{Matcher, FORMAT_PARAM};
 /// A Route is the basic data structure that stores both the path
 /// and the handler that gets executed for the route.
 /// The path can contain variable pattern such as `user/:userid/invoices`
-pub struct Route {
+pub struct Route<D=()> {
     pub method: Method,
-    pub handler: Box<Middleware + Send + Sync + 'static>,
+    pub handler: Box<Middleware<D> + Send + Sync + 'static>,
     matcher: Matcher
 }
 
@@ -20,12 +20,12 @@ pub struct Route {
 /// It contains the matched `route` and also a `params` property holding
 /// a HashMap with the keys being the variable names and the value being the
 /// evaluated string
-pub struct RouteResult<'mw> {
-    pub route: &'mw Route,
+pub struct RouteResult<'mw, D: 'mw = ()> {
+    pub route: &'mw Route<D>,
     params: Vec<(String, String)>
 }
 
-impl<'mw> RouteResult<'mw> {
+impl<'mw, D> RouteResult<'mw, D> {
     pub fn param(&self, key: &str) -> Option<&str> {
         for &(ref k, ref v) in &self.params {
             if k == &key {
@@ -45,18 +45,18 @@ impl<'mw> RouteResult<'mw> {
 /// The Router's job is it to hold routes and to resolve them later against
 /// concrete URLs. The router is also a regular middleware and needs to be
 /// added to the middleware stack with `server.utilize(router)`.
-pub struct Router {
-    routes: Vec<Route>,
+pub struct Router<D=()> {
+    routes: Vec<Route<D>>,
 }
 
-impl Router {
-    pub fn new () -> Router {
+impl<D> Router<D> {
+    pub fn new() -> Router<D> {
         Router {
             routes: Vec::new()
         }
     }
 
-    pub fn match_route<'mw>(&'mw self, method: &Method, path: &str) -> Option<RouteResult<'mw>> {
+    pub fn match_route<'mw>(&'mw self, method: &Method, path: &str) -> Option<RouteResult<'mw, D>> {
         self.routes
             .iter()
             .find(|item| item.method == *method && item.matcher.is_match(path))
@@ -69,7 +69,7 @@ impl Router {
     }
 }
 
-fn extract_params(route: &Route, path: &str) -> Vec<(String, String)> {
+fn extract_params<D>(route: &Route<D>, path: &str) -> Vec<(String, String)> {
     match route.matcher.captures(path) {
         Some(captures) => {
             captures.iter_named()
@@ -82,8 +82,8 @@ fn extract_params(route: &Route, path: &str) -> Vec<(String, String)> {
     }
 }
 
-impl HttpRouter for Router {
-    fn add_route<M: Into<Matcher>, H: Middleware>(&mut self, method: Method, matcher: M, handler: H) -> &mut Self {
+impl<D> HttpRouter<D> for Router<D> {
+    fn add_route<M: Into<Matcher>, H: Middleware<D>>(&mut self, method: Method, matcher: M, handler: H) -> &mut Self {
         let route = Route {
             matcher: matcher.into(),
             method: method,
@@ -95,9 +95,9 @@ impl HttpRouter for Router {
     }
 }
 
-impl Middleware for Router {
-    fn invoke<'mw, 'conn>(&'mw self, req: &mut Request<'mw, 'conn>, mut res: Response<'mw>)
-                          -> MiddlewareResult<'mw> {
+impl<D: 'static> Middleware<D> for Router<D> {
+    fn invoke<'mw, 'conn>(&'mw self, req: &mut Request<'mw, 'conn, D>, mut res: Response<'mw, D>)
+                          -> MiddlewareResult<'mw, D> {
         debug!("Router::invoke for '{:?}'", req.origin.uri);
 
         // Strip off the querystring when matching a route
@@ -191,7 +191,7 @@ fn creates_valid_regex_for_routes () {
 
 #[test]
 fn can_match_var_routes () {
-    let route_store = &mut Router::new();
+    let route_store = &mut Router::<()>::new();
 
     route_store.add_route(Method::Get, "/foo/:userid", middleware! { "hello from foo" });
     route_store.add_route(Method::Get, "/bar", middleware! { "hello from foo" });
@@ -256,7 +256,7 @@ fn can_match_var_routes () {
 
 #[test]
 fn params_lifetime() {
-    let route_store = &mut Router::new();
+    let route_store = &mut Router::<()>::new();
     let handler = middleware! { "hello from foo" };
 
     route_store.add_route(Method::Get, "/file/:format/:file", handler);
@@ -276,7 +276,7 @@ fn params_lifetime() {
 fn regex_path() {
     use regex::Regex;
 
-    let route_store = &mut Router::new();
+    let route_store = &mut Router::<()>::new();
 
     let regex = Regex::new("/(foo|bar)").unwrap();
     route_store.add_route(Method::Get, regex, middleware! { "hello from foo" });
@@ -298,7 +298,7 @@ fn regex_path() {
 fn regex_path_named() {
     use regex::Regex;
 
-    let route_store = &mut Router::new();
+    let route_store = &mut Router::<()>::new();
 
     let regex = Regex::new("/(?P<a>foo|bar)/b").unwrap();
     route_store.add_route(Method::Get, regex, middleware! { "hello from foo" });
@@ -323,7 +323,7 @@ fn regex_path_named() {
 fn ignores_querystring() {
     use regex::Regex;
 
-    let route_store = &mut Router::new();
+    let route_store = &mut Router::<()>::new();
 
     let regex = Regex::new("/(?P<a>foo|bar)/b").unwrap();
     route_store.add_route(Method::Get, regex, middleware! { "hello from foo" });

--- a/src/server.rs
+++ b/src/server.rs
@@ -9,32 +9,38 @@ use middleware::MiddlewareStack;
 use request;
 use response;
 
-pub struct Server {
-    middleware_stack: MiddlewareStack,
-    templates: response::TemplateCache
+pub struct Server<D> {
+    middleware_stack: MiddlewareStack<D>,
+    templates: response::TemplateCache,
+    shared_data: D,
 }
 
 // FIXME: Any better coherence solutions?
-struct ArcServer(Arc<Server>);
+struct ArcServer<D>(Arc<Server<D>>);
 
-impl Handler for ArcServer {
+impl<D: Sync + Send + 'static> Handler for ArcServer<D> {
     fn handle<'a, 'k>(&'a self, req: Request<'a, 'k>, res: Response<'a>) {
-        let req: Request<'a, 'k> = req;
-        let nickel_req = request::Request::from_internal(req);
-        let nickel_res = response::Response::from_internal(res, &self.0.templates);
+        let nickel_req = request::Request::from_internal(req,
+                                                         &self.0.shared_data);
+
+        let nickel_res = response::Response::from_internal(res,
+                                                           &self.0.templates,
+                                                           &self.0.shared_data);
+
         self.0.middleware_stack.invoke(nickel_req, nickel_res);
     }
 }
 
-impl Server {
-    pub fn new(middleware_stack: MiddlewareStack) -> Server {
+impl<D: Sync + Send + 'static> Server<D> {
+    pub fn new(middleware_stack: MiddlewareStack<D>, data: D) -> Server<D> {
         Server {
             middleware_stack: middleware_stack,
-            templates: RwLock::new(HashMap::new())
+            templates: RwLock::new(HashMap::new()),
+            shared_data: data
         }
     }
 
-    pub fn serve<T: ToSocketAddrs>(self, addr: T) -> HttpResult<Listening> {
+    pub fn serve<A: ToSocketAddrs>(self, addr: A) -> HttpResult<Listening> {
         let arc = ArcServer(Arc::new(self));
         let server = try!(HyperServer::http(addr));
         server.handle(arc)

--- a/tests/compile-fail/inference_fully_hinted.rs
+++ b/tests/compile-fail/inference_fully_hinted.rs
@@ -8,11 +8,11 @@ use nickel::{Nickel, HttpRouter, Request, Response};
 fn main() {
     let mut server = Nickel::new();
 
-    server.utilize(|_: &mut Request, res: Response| res.send("Hello World!"));
-    //~^ ERROR type mismatch resolving `for<'r,'b,'a> <[closure tests/com
+    server.utilize(|_: &mut Request<()>, res: Response<()>| res.send("Hello World!"));
+    //~^ ERROR type mismatch resolving `for<'
 
-    server.get("**", |_: &mut Request, res: Response| res.send("Hello World!"));
-    //~^ ERROR type mismatch resolving `for<'r,'b,'a> <[closure tests/com
+    server.get("**", |_: &mut Request<()>, res: Response<()>| res.send("Hello World!"));
+    //~^ ERROR type mismatch resolving `for<'
 
     server.listen("127.0.0.1:6767");
 }

--- a/tests/compile-fail/inference_no_hints.rs
+++ b/tests/compile-fail/inference_no_hints.rs
@@ -9,14 +9,14 @@ fn main() {
     let mut server = Nickel::new();
 
     server.utilize(|_, res| res.send("Hello World!"));
-    //~^ ERROR type mismatch resolving `for<'r,'b,'a> <[closure tests/compile-fail
+    //~^ ERROR type mismatch resolving `for<'
     //~^^ ERROR the type of this value must be known in this context
-    //~^^^ ERROR type mismatch: the type `[closure tests/compile
+    //~^^^ ERROR type mismatch: the type `[closure@tests/compile
 
     server.get("**", |_, res| res.send("Hello World!"));
-    //~^ ERROR type mismatch resolving `for<'r,'b,'a> <[closure tests/compile-fail
+    //~^ ERROR type mismatch resolving `for<'
     //~^^ ERROR the type of this value must be known in this context
-    //~^^^ ERROR type mismatch: the type `[closure tests/compile
+    //~^^^ ERROR type mismatch: the type `[closure@tests/compile
 
     server.listen("127.0.0.1:6767");
 }

--- a/tests/compile-fail/inference_request_hinted.rs
+++ b/tests/compile-fail/inference_request_hinted.rs
@@ -9,13 +9,13 @@ fn main() {
     let mut server = Nickel::new();
 
     // Request hinted
-    server.utilize(|_: &mut Request, res| res.send("Hello World!"));
+    server.utilize(|_: &mut Request<()>, res| res.send("Hello World!"));
     //~^ ERROR the type of this value must be known in this context
-    //~^^ ERROR type mismatch resolving `for<'r,'b,'a>
+    //~^^ ERROR type mismatch resolving `for<'
 
-    server.get("**", |_: &mut Request, res| res.send("Hello World!"));
+    server.get("**", |_: &mut Request<()>, res| res.send("Hello World!"));
     //~^ ERROR the type of this value must be known in this context
-    //~^^ ERROR type mismatch resolving `for<'r,'b,'a>
+    //~^^ ERROR type mismatch resolving `for<'
 
     server.listen("127.0.0.1:6767");
 }

--- a/tests/compile-fail/inference_response_hinted.rs
+++ b/tests/compile-fail/inference_response_hinted.rs
@@ -8,13 +8,13 @@ use nickel::{Nickel, HttpRouter, Request, Response};
 fn main() {
     let mut server = Nickel::new();
 
-    server.utilize(|_, res: Response| res.send("Hello World!"));
-    //~^ ERROR type mismatch resolving `for<'r,'b,'a> <[closure tests/compile-fail
-    //~^^ ERROR type mismatch: the type `[closure tests/compile-fail
+    server.utilize(|_, res: Response<()>| res.send("Hello World!"));
+    //~^ ERROR type mismatch resolving `for<'
+    //~^^ ERROR type mismatch: the type `[closure@tests/compile-fail
 
-    server.get("**", |_, res: Response| res.send("Hello World!"));
-    //~^ ERROR type mismatch resolving `for<'r,'b,'a> <[closure tests/compile-fail
-    //~^^ ERROR type mismatch: the type `[closure tests/compile-fail
+    server.get("**", |_, res: Response<()>| res.send("Hello World!"));
+    //~^ ERROR type mismatch resolving `for<'
+    //~^^ ERROR type mismatch: the type `[closure@tests/compile-fail
 
     server.listen("127.0.0.1:6767");
 }


### PR DESCRIPTION
I've ripped out the core from #272 and decided we should just push separate crates for now until the implementation for Session/Cookies has settled. This allows more breaking changes to the session/cookies implementations as we experiment without requiring a load of version bumps to nickel itself. It's more work for us to manage, but should be better for users :+1: 

I've also added a default type for the typeparam, so breakage in client crates should be minimal (until they start using the dataparam!) and only really affect people who've written library level stuff.

r? @cburgdorf @SimonPersson 