### PR TITLE
doc(mustache): add example using helper functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,12 @@ path = "examples/example_template.rs"
 
 [[example]]
 
+name = "template_helpers"
+path = "examples/template_helpers.rs"
+
+
+[[example]]
+
 name = "macro_example"
 path = "examples/macro_example.rs"
 

--- a/examples/assets/template.tpl
+++ b/examples/assets/template.tpl
@@ -2,4 +2,7 @@
     <h1>
         Hello {{ name }}!
     </h1>
+    {{#helper}}
+        Hello {{ name }} from a helper function
+    {{/helper}}
 {{> footer }}

--- a/examples/template_helpers.rs
+++ b/examples/template_helpers.rs
@@ -1,0 +1,26 @@
+extern crate mustache;
+#[macro_use] extern crate nickel;
+
+use nickel::{Nickel, HttpRouter, Halt};
+use mustache::MapBuilder;
+
+fn main() {
+    let mut server = Nickel::new();
+
+    server.get("/", middleware! { |_, res|
+        let data = MapBuilder::new()
+                              .insert_str("name", "user")
+                              .insert_fn("helper", |text| {
+                                  format!("<b>{}</b>", text.trim())
+                              }).build();
+
+        let template = try_with!(res, mustache::compile_path("examples/assets/template.tpl")
+                                               .map_err(|e| format!("{:?}", e)));
+
+        let mut stream = try!(res.start());
+        template.render_data(&mut stream, &data);
+        return Ok(Halt(stream))
+    });
+
+    server.listen("127.0.0.1:6767");
+}


### PR DESCRIPTION
Add a basic example of how to use mustache's more complicated features. I haven't touched the api on `Response` as I'd prefer that we started to migrate the mustache specific stuff out of the core.