### PR TITLE
perf(hyper): re-enable keep-alive by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,24 +5,25 @@ cache:
   directories:
       - target
 
-rust:
-  - stable
-  - nightly
-  - beta
-
 matrix:
   fast_finish: true
   allow_failures:
     - rust: nightly
+  include:
+      - rust: 1.3.0 # minimum supported rustc version
+        env: FEATURES="--no-default-features"
+      - rust: stable
+      - rust: beta
+      - rust: nightly
 
 before_script:
   - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
 
 script:
   - |
-      travis-cargo build &&
-      travis-cargo test &&
-      travis-cargo doc &&
+      travis-cargo build -- $FEATURES &&
+      travis-cargo test -- $FEATURES &&
+      travis-cargo doc -- $FEATURES &&
       echo "Testing README" &&
       rustdoc --test README.md -L dependency=./target/debug/deps --extern nickel=./target/debug/libnickel.rlib
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ keywords = ["nickel", "server", "web", "express"]
 [features]
 unstable = ["hyper/nightly", "compiletest_rs"]
 ssl = ["hyper/ssl"]
+timeouts = ["hyper/timeouts"]
+default = ["timeouts"]
 
 [dependencies]
 url = "*"

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,6 +1,7 @@
 use std::net::ToSocketAddrs;
 use std::sync::{Arc, RwLock};
 use std::collections::HashMap;
+use std::time::Duration;
 use hyper::Result as HttpResult;
 use hyper::server::{Request, Response, Handler, Listening};
 use hyper::server::Server as HyperServer;
@@ -40,9 +41,14 @@ impl<D: Sync + Send + 'static> Server<D> {
         }
     }
 
-    pub fn serve<A: ToSocketAddrs>(self, addr: A) -> HttpResult<Listening> {
+    pub fn serve<A: ToSocketAddrs>(self, addr: A, keep_alive_timeout: Option<Duration>) -> HttpResult<Listening> {
         let arc = ArcServer(Arc::new(self));
-        let server = try!(HyperServer::http(addr));
+        let mut server = try!(HyperServer::http(addr));
+
+        if let Some(timeout) = keep_alive_timeout {
+            server.keep_alive(timeout);
+        }
+
         server.handle(arc)
     }
 }


### PR DESCRIPTION
This was disabled in hyper 0.6.15 which gave a significant performance regression. 

In the same release though `socket_timeouts` related code was included which allows us to add timeouts on the socket which should prevent threads being stalled indefinitely. With the `timeouts` features enabled this should match 0.6.14 performance and not lead to exhausted servers (although it can still happen, but they will recover, unlike before).

When the `timeouts` feature is disabled (to compile on 1.3), the performance should match the previous, but the keep-alive issues that were previously present will still occur, so it's probably best for users of 1.3 to either upgrade or to set `keep_alive_timeout` to `None`. 

I'm unsure if we should continue to support 1.3 with such a limitation. (especially since 1.4 is now stable)

cc @ruizander @cburgdorf @SimonPersson 