### PR TITLE
doc(examples): Point to correct crate

### DIFF
--- a/examples/template.rs
+++ b/examples/template.rs
@@ -7,7 +7,7 @@ fn main() {
     let mut server = Nickel::new();
 
     // * NOTE *
-    // This example is deprecated, you should use nickel-mustache from crates.io
+    // This example is deprecated, you should use nickel_mustache from crates.io
     server.get("/", middleware! { |_, res|
         let mut data = HashMap::<&str, &str>::new();
         data.insert("name", "user");


### PR DESCRIPTION
Seems the crate is [written with an underscore](https://crates.io/crates/nickel_mustache)