### PR TITLE
Upgrade hyper/mime/url

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   allow_failures:
     - rust: nightly
   include:
-      - rust: 1.3.0 # minimum supported rustc version
+      - rust: 1.5.0 # minimum supported rustc version
         env: FEATURES="--no-default-features"
       - rust: stable
       - rust: beta

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,9 @@ keywords = ["nickel", "server", "web", "express"]
 [features]
 unstable = ["hyper/nightly", "compiletest_rs"]
 ssl = ["hyper/ssl"]
-timeouts = ["hyper/timeouts"]
-default = ["timeouts"]
 
 [dependencies]
-url = "0.2"
+url = "0.5"
 time = "0.1"
 typemap = "0.3"
 plugin = "0.2"
@@ -32,7 +30,7 @@ lazy_static = "0.1"
 modifier = "0.1"
 
 [dependencies.hyper]
-version = "=0.6"
+version = "=0.8"
 default-features = false
 
 [dependencies.compiletest_rs]

--- a/src/server.rs
+++ b/src/server.rs
@@ -45,9 +45,7 @@ impl<D: Sync + Send + 'static> Server<D> {
         let arc = ArcServer(Arc::new(self));
         let mut server = try!(HyperServer::http(addr));
 
-        if let Some(timeout) = keep_alive_timeout {
-            server.keep_alive(timeout);
-        }
+        server.keep_alive(keep_alive_timeout);
 
         server.handle(arc)
     }


### PR DESCRIPTION
The `examples/template.rs` example fails but it says it's deprecated? Anyways, the assertion fails because the line endings changed, probably because I'm on Windows and Git checks out with CRLF line endings by default.

```
failures:

---- examples::template::renders_data stdout ----
        Parsed: port=58433 from "Listening on http://[::1]:58433"
thread 'examples::template::renders_data' panicked at 'assertion failed: `(left == right)` (left: `"<html>\r\n
   <head>\r\n        <title>\r\n            nickel.rs - example\r\n        </title>\r\n    </head>\r\n    <body>\r\n    <h1>\r\n        Hello user!\r\n    </h1>\r\n    </body>\r\n</html>"`, right: `"<html>\n    <head>\n
     <title>\n            nickel.rs - example\n        </title>\n    </head>\n    <body>\n    <h1>\n        Hello user!\n    </h1>\n    </body>\n</html>"`)', tests\examples\template.rs:23
Unparsed Stdout:
```

Edit: forgot to add this:

Closes #318 