### PR TITLE
chore(travis): bump minimum rust version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 sudo: false
 
 rust:
-  - 1.5.0 # minimum supported rustc version
+  - 1.7.0 # minimum supported rustc version
   - stable
   - beta
   - nightly
@@ -12,7 +12,7 @@ matrix:
   allow_failures:
     - rust: nightly
   include:
-      - rust: 1.5.0 # minimum supported rustc version
+      - rust: 1.7.0 # minimum supported rustc version
         env: FEATURES="--no-default-features"
 
 before_script:


### PR DESCRIPTION
Rust 1.7 is new minimum due to url bumping to new uuid version (which added no_std support) and cookie bumping to url 1.0 which depends on IpAddr which was destabilized in 1.6 and then restabilized in 1.7.