### PR TITLE
feat(server): return `ListeningServer` from `Nickel::listen`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,11 @@ path = "examples/route_data.rs"
 
 [[example]]
 
+name = "integration_testing"
+path = "examples/integration_testing.rs"
+
+[[example]]
+
 name = "static_files"
 path = "examples/static_files.rs"
 

--- a/examples/chaining.rs
+++ b/examples/chaining.rs
@@ -13,5 +13,5 @@ fn main() {
           .patch("/patch", middleware!("patch"))
           .delete("/delete", middleware!("delete"));
 
-    server.listen("127.0.0.1:6767");
+    server.listen("127.0.0.1:6767").unwrap();
 }

--- a/examples/custom_error_handler.rs
+++ b/examples/custom_error_handler.rs
@@ -47,5 +47,5 @@ fn main() {
 
     server.handle_error(custom_handler);
 
-    server.listen("127.0.0.1:6767");
+    server.listen("127.0.0.1:6767").unwrap();
 }

--- a/examples/enable_cors.rs
+++ b/examples/enable_cors.rs
@@ -25,5 +25,5 @@ fn main() {
     let mut server = Nickel::new();
     server.utilize(enable_cors);
     server.get("**", middleware!("Hello CORS Enabled World"));
-    server.listen("127.0.0.1:6767");
+    server.listen("127.0.0.1:6767").unwrap();
 }

--- a/examples/form_data/form_data.rs
+++ b/examples/form_data/form_data.rs
@@ -26,5 +26,5 @@ fn main() {
         return res.render("examples/form_data/views/confirmation.html", &data)
     });
 
-    server.listen("0.0.0.0:8080");
+    server.listen("0.0.0.0:8080").unwrap();
 }

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -9,5 +9,5 @@ fn hello_world<'mw>(_req: &mut Request, res: Response<'mw>) -> MiddlewareResult<
 fn main() {
     let mut server = Nickel::new();
     server.get("**", hello_world);
-    server.listen("127.0.0.1:6767");
+    server.listen("127.0.0.1:6767").unwrap();
 }

--- a/examples/hello_world_macro.rs
+++ b/examples/hello_world_macro.rs
@@ -5,5 +5,5 @@ use nickel::{Nickel, HttpRouter};
 fn main() {
     let mut server = Nickel::new();
     server.get("**", middleware!("Hello World"));
-    server.listen("127.0.0.1:6767");
+    server.listen("127.0.0.1:6767").unwrap();
 }

--- a/examples/https.rs
+++ b/examples/https.rs
@@ -10,7 +10,7 @@ fn main() {
     let ssl = Openssl::with_cert_and_key("examples/assets/self_signed.crt", "examples/assets/key.pem").unwrap();
     let mut server = Nickel::new();
     server.get("**", middleware!("Hello World from HTTPS"));
-    server.listen_https("127.0.0.1:6767", ssl);
+    server.listen_https("127.0.0.1:6767", ssl).unwrap();
 }
 
 #[cfg(not(feature = "ssl"))]

--- a/examples/integration_testing.rs
+++ b/examples/integration_testing.rs
@@ -1,4 +1,6 @@
-#[macro_use]
+// This attribute being conditional is an implementation detail of the nickel
+// test setup for testing examples. Usually, it should just require `#[macro_use]`.
+#[cfg_attr(not(test), macro_use)]
 extern crate nickel;
 extern crate hyper;
 extern crate rustc_serialize;

--- a/examples/integration_testing.rs
+++ b/examples/integration_testing.rs
@@ -12,24 +12,75 @@ use std::error::Error as StdError;
 use std::{env, str};
 use std::sync::atomic::{self, AtomicUsize};
 
-fn main() {
-    let port = env::var("PORT").map(|s| s.parse().unwrap()).unwrap_or(3000);
-
-    start_server(&format!("0.0.0.0:{}", port)).unwrap();
+// Example trait to allow custom databases to be used within the integration tests
+// to test different behaviours without touching a real database.
+trait Database : Send + Sync + 'static {
+    fn get_users(&self) -> Vec<String>;
 }
 
-fn start_server(address: &str) -> Result<ListeningServer, Box<StdError>> {
-    let hits = AtomicUsize::new(0);
-    let mut server = Nickel::with_data(hits);
+impl Database for Vec<String> {
+    fn get_users(&self) -> Vec<String> {
+        self.clone()
+    }
+}
+
+struct ServerData {
+    hits: AtomicUsize,
+
+    // FIXME: The `middleware` macro typehinting doesn't support hinting with
+    // typeparams, i.e. the hint can't be `< ServerData<T> >` where T is a
+    // typeparam from the enclosing function, e.g. `start_server`.
+    //
+    // To counter this limitation, we've boxed the trait so that specifying the
+    // typeparam is unnecessary.
+    database: Box<Database>
+}
+
+impl ServerData {
+    fn hitcount(&self) -> usize {
+        self.hits.load(atomic::Ordering::Relaxed)
+    }
+
+    fn log_hit(&self) -> usize {
+        self.hits.fetch_add(1, atomic::Ordering::Relaxed)
+    }
+
+    fn get_users(&self) -> Vec<String> {
+        self.database.get_users()
+    }
+}
+
+fn main() {
+    let port = env::var("PORT").map(|s| s.parse().unwrap()).unwrap_or(3000);
+    let address = &format!("0.0.0.0:{}", port);
+    let database = vec![];
+
+    start_server(address, database).unwrap();
+}
+
+fn start_server<D>(address: &str, database: D) -> Result<ListeningServer, Box<StdError>>
+where D: Database {
+    let server_data = ServerData {
+        hits: AtomicUsize::new(0),
+        database: Box::new(database),
+    };
+
+    let mut server = Nickel::with_data(server_data);
 
     // Track all hits to the server
-    server.utilize(middleware! { |_req, res| <AtomicUsize>
-        let _hits = res.data().fetch_add(1, atomic::Ordering::Relaxed);
+    server.utilize(middleware! { |_req, res| <ServerData>
+        res.data().log_hit();
         return res.next_middleware()
     });
 
     // Core server
     server.get("/", middleware!( "Hello World" ));
+
+    server.get("/users", middleware! { |_, res| <ServerData>
+        let users = res.data().get_users();
+
+        Json::from_str(&format!(r#"{{ "users": {:?} }}"#, users)).unwrap()
+    });
 
     // Json example
     server.post("/", middleware! { |req, res|
@@ -56,10 +107,8 @@ fn start_server(address: &str) -> Result<ListeningServer, Box<StdError>> {
     });
 
     // Get the hitcount
-    server.get("/hits", middleware!{ |_req, res| <AtomicUsize>
-        let hits = res.data().load(atomic::Ordering::Relaxed);
-
-        hits.to_string()
+    server.get("/hits", middleware!{ |_req, res| <ServerData>
+        res.data().hitcount().to_string()
     });
 
     server.listen(address)
@@ -135,11 +184,45 @@ mod tests {
     #[test]
     fn non_shared_server() {
         let test_local_server = {
-            let server = super::start_server("127.0.0.1:0").unwrap();
+            let server = super::start_server("127.0.0.1:0", vec![]).unwrap();
             Server::new(server)
         };
 
         assert_eq!(get_hits_after_delay(&test_local_server), 1);
+    }
+
+    #[test]
+    fn has_no_users_by_default() {
+        let mut response = get("/users");
+
+        let json = Json::from_str(&response.body()).unwrap();
+
+        assert_eq!(json["users"].as_array().unwrap().len(), 0);
+        assert_eq!(response.status, StatusCode::Ok);
+        assert_eq!(
+            response.headers.get::<header::ContentType>(),
+            Some(&header::ContentType::json())
+        );
+    }
+
+    #[test]
+    fn non_shared_server_with_different_database() {
+        let server = {
+            let bots = vec!["bors".into(), "homu".into(), "highfive".into()];
+            let server = super::start_server("127.0.0.1:0", bots).unwrap();
+            Server::new(server)
+        };
+
+        let mut response = server.get("/users");
+
+        let json = Json::from_str(&response.body()).unwrap();
+
+        assert_eq!(json["users"].as_array().unwrap().len(), 3);
+        assert_eq!(response.status, StatusCode::Ok);
+        assert_eq!(
+            response.headers.get::<header::ContentType>(),
+            Some(&header::ContentType::json())
+        );
     }
 
     mod support {
@@ -192,7 +275,7 @@ mod tests {
         lazy_static! {
             /// This is a shared instance of the server between all the tests
             pub static ref STATIC_SERVER: Server = {
-                let server = super::super::start_server("127.0.0.1:0").unwrap();
+                let server = super::super::start_server("127.0.0.1:0", vec![]).unwrap();
                 Server::new(server)
             };
         }

--- a/examples/integration_testing.rs
+++ b/examples/integration_testing.rs
@@ -1,0 +1,210 @@
+#[macro_use]
+extern crate nickel;
+extern crate hyper;
+extern crate rustc_serialize;
+
+use nickel::{Nickel, ListeningServer, HttpRouter, JsonBody};
+use nickel::status::StatusCode;
+
+use rustc_serialize::json::Json;
+
+use std::error::Error as StdError;
+use std::{env, str};
+use std::sync::atomic::{self, AtomicUsize};
+
+fn main() {
+    let port = env::var("PORT").map(|s| s.parse().unwrap()).unwrap_or(3000);
+
+    start_server(&format!("0.0.0.0:{}", port)).unwrap();
+}
+
+fn start_server(address: &str) -> Result<ListeningServer, Box<StdError>> {
+    let hits = AtomicUsize::new(0);
+    let mut server = Nickel::with_data(hits);
+
+    // Track all hits to the server
+    server.utilize(middleware! { |_req, res| <AtomicUsize>
+        let _hits = res.data().fetch_add(1, atomic::Ordering::Relaxed);
+        return res.next_middleware()
+    });
+
+    // Core server
+    server.get("/", middleware!( "Hello World" ));
+
+    // Json example
+    server.post("/", middleware! { |req, res|
+        #[derive(RustcEncodable, RustcDecodable)]
+        struct Data { name: String, age: Option<u32> }
+
+        let client = try_with!(res, req.json_as::<Data>().map_err(|e| (StatusCode::BadRequest, e)));
+
+        match client.age {
+            Some(age) => {
+                Json::from_str(&format!(
+                    r#"{{ "message": "Hello {}, your age is {}" }}"#,
+                    client.name,
+                    age
+                )).unwrap()
+            }
+            None => {
+                Json::from_str(&format!(
+                    r#"{{ "message": "Hello {}, I don't know your age" }}"#,
+                    client.name
+                )).unwrap()
+            }
+        }
+    });
+
+    // Get the hitcount
+    server.get("/hits", middleware!{ |_req, res| <AtomicUsize>
+        let hits = res.data().load(atomic::Ordering::Relaxed);
+
+        hits.to_string()
+    });
+
+    server.listen(address)
+}
+
+#[cfg(test)]
+mod tests {
+    use self::support::{Body, Server, STATIC_SERVER, get, post};
+
+    use hyper::header;
+    use nickel::status::StatusCode;
+    use rustc_serialize::json::Json;
+
+    use std::{thread, time};
+
+    fn get_hits_after_delay(server: &Server) -> u32 {
+        // let other tests hit the server
+        thread::sleep(time::Duration::from_secs(1));
+
+        let mut response = server.get("/hits");
+        response.body().parse().unwrap()
+    }
+
+    #[test]
+    fn root_responds_with_hello_world() {
+        let mut response = get("/");
+
+        assert_eq!(response.body(), "Hello World");
+        assert_eq!(response.status, StatusCode::Ok);
+    }
+
+    #[test]
+    // FIXME: This will probably fail if tests are run without parallelism
+    fn server_is_shared_with_other_tests() {
+        assert!(get_hits_after_delay(&STATIC_SERVER) > 1);
+    }
+
+    #[test]
+    fn root_responds_with_modified_json() {
+        let mut response = post("/", r#"{ "name": "Rust", "age": 1 }"#);
+
+        let json = Json::from_str(&response.body()).unwrap();
+
+        assert_eq!(json["message"].as_string(), Some("Hello Rust, your age is 1"));
+        assert_eq!(response.status, StatusCode::Ok);
+        assert_eq!(
+            response.headers.get::<header::ContentType>(),
+            Some(&header::ContentType::json())
+        );
+    }
+
+    #[test]
+    fn accepts_json_with_missing_fields() {
+        let mut response = post("/", r#"{ "name": "Rust" }"#);
+
+        let json = Json::from_str(&response.body()).unwrap();
+
+        assert_eq!(json["message"].as_string(), Some("Hello Rust, I don't know your age"));
+        assert_eq!(response.status, StatusCode::Ok);
+        assert_eq!(
+            response.headers.get::<header::ContentType>(),
+            Some(&header::ContentType::json())
+        );
+    }
+
+    #[test]
+    fn doesnt_accept_bad_inputs() {
+        let response = post("/", r#"{ }"#);
+        assert_eq!(response.status, StatusCode::BadRequest);
+    }
+
+    /// This test has a Server instance all to itself.
+    #[test]
+    fn non_shared_server() {
+        let test_local_server = {
+            let server = super::start_server("127.0.0.1:0").unwrap();
+            Server::new(server)
+        };
+
+        assert_eq!(get_hits_after_delay(&test_local_server), 1);
+    }
+
+    mod support {
+        use hyper::client::{Client, Response as HyperResponse};
+        use nickel::ListeningServer;
+
+        use std::net::SocketAddr;
+
+        pub trait Body {
+            fn body(self) -> String;
+        }
+
+        impl<'a> Body for &'a mut HyperResponse {
+            fn body(self) -> String {
+                use std::io::Read;
+                let mut body = String::new();
+                self.read_to_string(&mut body).expect("Failed to read body of Response");
+                println!("Read body: {}", body);
+                body
+            }
+        }
+
+        /// An example wrapper type to make testing more readable
+        pub struct Server(SocketAddr);
+        impl Server {
+            pub fn new(server: ListeningServer) -> Server {
+                let wrapped = Server(server.socket());
+
+                // detaching is important otherwise it would block the test threads.
+                server.detach();
+
+                wrapped
+            }
+
+            pub fn get(&self, path: &str) -> HyperResponse {
+                let url = self.url_for(path);
+                Client::new().get(&url).send().unwrap()
+            }
+
+            pub fn post(&self, path: &str, body: &str) -> HyperResponse {
+                let url = self.url_for(path);
+                Client::new().post(&url).body(body).send().unwrap()
+            }
+
+            pub fn url_for(&self, path: &str) -> String {
+                format!("http://{}{}", self.0, path)
+            }
+        }
+
+        lazy_static! {
+            /// This is a shared instance of the server between all the tests
+            pub static ref STATIC_SERVER: Server = {
+                let server = super::super::start_server("127.0.0.1:0").unwrap();
+                Server::new(server)
+            };
+        }
+
+        /// Example of a free function version of `get` which uses the shared server
+        pub fn get(path: &str) -> HyperResponse {
+            STATIC_SERVER.get(path)
+        }
+
+        /// Example of a free function version of `post` which uses the shared server
+        pub fn post(path: &str, body: &str) -> HyperResponse {
+            STATIC_SERVER.post(path, body)
+        }
+    }
+}

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -52,5 +52,5 @@ fn main() {
         r#"{ "foo": "bar" }"#
     });
 
-    server.listen("127.0.0.1:6767");
+    server.listen("127.0.0.1:6767").unwrap();
 }

--- a/examples/logger_middleware.rs
+++ b/examples/logger_middleware.rs
@@ -34,5 +34,5 @@ fn main() {
     server.utilize(logger_fn);
     server.utilize(Logger);
 
-    server.listen("127.0.0.1:6767");
+    server.listen("127.0.0.1:6767").unwrap();
 }

--- a/examples/macro_example.rs
+++ b/examples/macro_example.rs
@@ -127,5 +127,5 @@ fn main() {
     server.handle_error(custom_handler);
 
     println!("Running server!");
-    server.listen("127.0.0.1:6767");
+    server.listen("127.0.0.1:6767").unwrap();
 }

--- a/examples/mount.rs
+++ b/examples/mount.rs
@@ -24,5 +24,5 @@ fn main() {
         format!("No static file with path '{}'!", path)
     });
 
-    server.listen("127.0.0.1:6767");
+    server.listen("127.0.0.1:6767").unwrap();
 }

--- a/examples/moved_ownership.rs
+++ b/examples/moved_ownership.rs
@@ -25,5 +25,5 @@ fn main() {
     // the value by 'ref' by doing `&*x` (the additional `*` in this case is to
     // deref from `String` to `str`).
     server.get("**", middleware!(&*x));
-    server.listen("127.0.0.1:6767");
+    server.listen("127.0.0.1:6767").unwrap();
 }

--- a/examples/query_string.rs
+++ b/examples/query_string.rs
@@ -25,5 +25,5 @@ fn main() {
         }
     });
 
-    server.listen("127.0.0.1:6767");
+    server.listen("127.0.0.1:6767").unwrap();
 }

--- a/examples/regex_route.rs
+++ b/examples/regex_route.rs
@@ -13,5 +13,5 @@ fn main() {
         format!("Hello {}", request.param("name").unwrap())
     });
 
-    server.listen("127.0.0.1:6767");
+    server.listen("127.0.0.1:6767").unwrap();
 }

--- a/examples/route_data.rs
+++ b/examples/route_data.rs
@@ -28,5 +28,5 @@ fn main() {
         format!("{}", shared_visits.fetch_add(1, Relaxed))
     });
 
-    server.listen("127.0.0.1:6767");
+    server.listen("127.0.0.1:6767").unwrap();
 }

--- a/examples/routing.rs
+++ b/examples/routing.rs
@@ -28,7 +28,7 @@ fn main() {
         format!("Foo is '{}'. The requested format is '{}'", foo, format)
     });
 
-    server.listen("127.0.0.1:6767");
+    server.listen("127.0.0.1:6767").unwrap();
 }
 
 fn explicit_router() -> nickel::Router {

--- a/examples/static_files.rs
+++ b/examples/static_files.rs
@@ -11,5 +11,5 @@ fn main() {
     // go to http://localhost:6767/thoughtram_logo_brain.png to see static file serving in action
     server.utilize(StaticFilesHandler::new("examples/assets/"));
 
-    server.listen("127.0.0.1:6767");
+    server.listen("127.0.0.1:6767").unwrap();
 }

--- a/examples/template.rs
+++ b/examples/template.rs
@@ -14,5 +14,5 @@ fn main() {
         return res.render("examples/assets/template.tpl", &data)
     });
 
-    server.listen("127.0.0.1:6767");
+    server.listen("127.0.0.1:6767").unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub use router::{Router, Route, RouteResult, HttpRouter};
 pub use nickel_error::NickelError;
 pub use mimes::MediaType;
 pub use responder::Responder;
+pub use server::ListeningServer;
 
 #[macro_use] pub mod macros;
 

--- a/src/macros/middleware.rs
+++ b/src/macros/middleware.rs
@@ -20,7 +20,7 @@
 ///     format!("{}", visits.fetch_add(1, Ordering::Relaxed))
 /// });
 ///
-/// server.listen("127.0.0.1:6767");
+/// server.listen("127.0.0.1:6767").unwrap();
 /// # }
 /// ```
 ///

--- a/tests/compile-fail/inference_fully_hinted.rs
+++ b/tests/compile-fail/inference_fully_hinted.rs
@@ -14,5 +14,5 @@ fn main() {
     server.get("**", |_: &mut Request<()>, res: Response<()>| res.send("Hello World!"));
     //~^ ERROR type mismatch resolving `for<'
 
-    server.listen("127.0.0.1:6767");
+    server.listen("127.0.0.1:6767").unwrap();
 }

--- a/tests/compile-fail/inference_no_hints.rs
+++ b/tests/compile-fail/inference_no_hints.rs
@@ -15,5 +15,5 @@ fn main() {
     server.get("**", |_, res| res.send("Hello World!"));
     //~^ ERROR type mismatch resolving `for<'
 
-    server.listen("127.0.0.1:6767");
+    server.listen("127.0.0.1:6767").unwrap();
 }

--- a/tests/compile-fail/inference_request_hinted.rs
+++ b/tests/compile-fail/inference_request_hinted.rs
@@ -16,5 +16,5 @@ fn main() {
     server.get("**", |_: &mut Request<()>, res| res.send("Hello World!"));
     //~^ ERROR type mismatch resolving `for<'
 
-    server.listen("127.0.0.1:6767");
+    server.listen("127.0.0.1:6767").unwrap();
 }

--- a/tests/compile-fail/inference_response_hinted.rs
+++ b/tests/compile-fail/inference_response_hinted.rs
@@ -14,5 +14,5 @@ fn main() {
     server.get("**", |_, res: Response<()>| res.send("Hello World!"));
     //~^ ERROR type mismatch resolving `for<'
 
-    server.listen("127.0.0.1:6767");
+    server.listen("127.0.0.1:6767").unwrap();
 }

--- a/tests/example_tests.rs
+++ b/tests/example_tests.rs
@@ -1,5 +1,11 @@
 extern crate rustc_serialize;
 extern crate hyper;
+// HACK: integration_testing example refers to `nickel::foo`
+// and this import helps that resolve rather than requiring `self::nickel::foo`
+// which is an oddity due to the include method, which is used as tests in examples
+// don't get executed otherwise.
+#[macro_use]
+extern crate nickel;
 
 #[macro_use] extern crate lazy_static;
 
@@ -20,6 +26,7 @@ mod examples {
     mod static_files;
     mod enable_cors;
     mod form_data;
+    mod integration_testing;
 
     #[cfg(feature = "ssl")]
     mod https;

--- a/tests/examples/integration_testing.rs
+++ b/tests/examples/integration_testing.rs
@@ -1,0 +1,5 @@
+// HACK: Need cargo support to run `#[test]`s witin examples, this imitates it.
+
+#![allow(dead_code)]
+#![allow(unused_attributes)]
+include!("../../examples/integration_testing.rs");


### PR DESCRIPTION
Related to #328.

The tests within this repo are a bit of a hack (require shelling out to subprocesses involving cargo), with this change we can instead make it *easier* to integration test a server (or multiple instances of one) all within the same process which should be easier and faster.

The code within the integration test example would get tested using a normal `cargo test`, but since it's in our example files I had to use a workaround to get it compiled directly into our integration test runner.

BREAKING CHANGE: This changes the return type of `Nickel::listen`, you can add an `unwrap()` to the call to maintain previous semantics.