### PR TITLE
fix(deps): force bitflags v0.5 if ssl is enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["nickel", "server", "web", "express"]
 
 [features]
 unstable = ["hyper/nightly", "compiletest_rs"]
-ssl = ["hyper/ssl"]
+ssl = ["hyper/ssl", "bitflags"]
 
 [dependencies]
 url = "0.5"
@@ -32,6 +32,11 @@ modifier = "0.1"
 [dependencies.hyper]
 version = "=0.8"
 default-features = false
+
+[dependencies.bitflags]
+# This lets us compile openssl on rustc below v1.8.0
+version = "0.5"
+optional = true
 
 [dependencies.compiletest_rs]
 version = "0.1"


### PR DESCRIPTION
This should allow us to continue building on rustc 1.7 rather than requiring 1.8, 
which is currently the very latest version released. 

We could remove this when we next version bump if we want.

r? @SimonPersson @cburgdorf 