### PR TITLE
fix(travis): Don't fail the build when minimum rustc version fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 sudo: false
 
 rust:
-  - 1.7.0 # minimum supported rustc version
+  - 1.8.0 # minimum supported rustc version
   - stable
   - beta
   - nightly
@@ -11,8 +11,11 @@ matrix:
   fast_finish: true
   allow_failures:
     - rust: nightly
+    # Don't fail the build if a dependency updates, but at least have a canary so
+    # we know when it happens.
+    - rust: 1.8.0
   include:
-      - rust: 1.7.0 # minimum supported rustc version
+      - rust: 1.8.0 # minimum supported rustc version
         env: FEATURES="--no-default-features"
 
 before_script:

--- a/tests/compile-fail/inference_no_hints.rs
+++ b/tests/compile-fail/inference_no_hints.rs
@@ -14,7 +14,6 @@ fn main() {
 
     server.get("**", |_, res| res.send("Hello World!"));
     //~^ ERROR type mismatch resolving `for<'
-    //~^^ ERROR the type of this value must be known in this context
 
     server.listen("127.0.0.1:6767");
 }

--- a/tests/compile-fail/inference_request_hinted.rs
+++ b/tests/compile-fail/inference_request_hinted.rs
@@ -14,8 +14,7 @@ fn main() {
     //~^^ ERROR type mismatch resolving `for<'
 
     server.get("**", |_: &mut Request<()>, res| res.send("Hello World!"));
-    //~^ ERROR the type of this value must be known in this context
-    //~^^ ERROR type mismatch resolving `for<'
+    //~^ ERROR type mismatch resolving `for<'
 
     server.listen("127.0.0.1:6767");
 }


### PR DESCRIPTION
This still keeps the minimum rustc version tested on travis as a canary for when things do inevitably fail in future.