### PR TITLE
feat(hyper): add re-export for Method

### DIFF
--- a/src/favicon_handler.rs
+++ b/src/favicon_handler.rs
@@ -3,12 +3,12 @@ use std::path::{PathBuf, Path};
 use std::io::Read;
 
 use hyper::uri::RequestUri::AbsolutePath;
-use hyper::method::Method::{Get, Head, Options};
 use hyper::status::StatusCode;
 use hyper::header;
 
 use request::Request;
 use response::Response;
+use method::Method::{Get, Head, Options};
 use middleware::{Middleware, MiddlewareResult};
 use mimes::MediaType;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,3 +54,7 @@ pub mod extensions;
 pub mod status {
     pub use hyper::status::StatusCode;
 }
+
+pub mod method {
+    pub use hyper::method::Method;
+}

--- a/src/nickel.rs
+++ b/src/nickel.rs
@@ -5,9 +5,9 @@ use std::error::Error as StdError;
 use router::{Router, HttpRouter, Matcher};
 use middleware::{MiddlewareStack, Middleware, ErrorHandler};
 use server::{Server, ListeningServer};
-use hyper::method::Method;
+use method::Method;
+use status::StatusCode;
 use hyper::net::SslServer;
-use hyper::status::StatusCode;
 
 //pre defined middleware
 use default_error_handler::DefaultErrorHandler;

--- a/src/router/http_router.rs
+++ b/src/router/http_router.rs
@@ -1,4 +1,4 @@
-use hyper::method::Method;
+use method::Method;
 use middleware::Middleware;
 use router::Matcher;
 

--- a/src/router/router.rs
+++ b/src/router/router.rs
@@ -3,8 +3,8 @@ use middleware::{Middleware, MiddlewareResult};
 use request::Request;
 use response::Response;
 use router::HttpRouter;
-use hyper::method::Method;
-use hyper::status::StatusCode;
+use method::Method;
+use status::StatusCode;
 use router::{Matcher, FORMAT_PARAM};
 
 /// A Route is the basic data structure that stores both the path

--- a/src/static_files_handler.rs
+++ b/src/static_files_handler.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 use std::io::ErrorKind::NotFound;
 use std::fs;
 
-use hyper::method::Method::{Get, Head};
+use method::Method::{Get, Head};
 
 use status::StatusCode;
 use request::Request;


### PR DESCRIPTION
I use nickel-0.8.1 for server side and h hyper-0.9.3 for client side.
Unfortunatelly I can't add route for HEAD method without this change :(
