### PR TITLE
fix(test): fix examples::template::renders_data test on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+﻿*.tpl			text eol=lf


### PR DESCRIPTION
By default Git use native line endings for all text files.

This change fix line ending test issue:
```
test examples::static_files::nested_files ... ok
test examples::static_files::returns_expected_files ... ok
test examples::template::renders_data ... FAILED

failures:

---- examples::template::renders_data stdout ----
        Processing Stdout: "Listening on http://127.0.0.1:63210"
Parsed: port=63210 from "Listening on http://127.0.0.1:63210"
thread 'examples::template::renders_data' panicked at 'assertion failed: `(left == right)` (left: `"<html>\r\n    <head>\r\n        <title>\r\n            nickel.rs - example\r\n        </title>\r\n    </head>\r\n
    <body>\r\n    <h1>\r\n        Hello user!\r\n    </h1>\r\n    </body>\r\n</html>"`, right: `"<html>\n    <head>\n        <title>\n            nickel.rs - example\n        </title>\n    </head>\n    <body>\n
 <h1>\n        Hello user!\n    </h1>\n    </body>\n</html>"`)', tests\examples\template.rs:23
Unparsed Stdout:
Ctrl-C to shutdown server



failures:
    examples::template::renders_data

test result: FAILED. 66 passed; 1 failed; 0 ignored; 0 measured
```