### PR TITLE
docs(https.rs): add hint for ssl feature compilation

### DIFF
--- a/examples/https.rs
+++ b/examples/https.rs
@@ -11,18 +11,12 @@ fn main() {
     let mut server = Nickel::new();
     server.get("**", middleware!("Hello World from HTTPS"));
     
-    /*
-     * Hint: If you want to use the `listen_https` function in your own crate / module / project, you need to
-     * add `nickel/ssl` to the features section of your crate configuration, to get nickel compiled
-     * with ssl feature activated:
-     * 
-     * Cargo.toml >
-     *      [features]
-     *      ssl = ["nickel/ssl"]
-     *
-     * As you can see, to append `hyper/ssl` in the features section is obsolete, as hyper will get compiled with
-     * ssl feature activated via `nickel/ssl`.
-    */
+    // To get nickel compiled with ssl feature activated, you need to configure the module like shown below:
+    //
+    // Cargo.toml >
+    //      [dependencies.nickel]
+    //      version = "0.8"
+    //      features = ["ssl"]
     server.listen_https("127.0.0.1:6767", ssl);
 }
 

--- a/examples/https.rs
+++ b/examples/https.rs
@@ -10,6 +10,19 @@ fn main() {
     let ssl = Openssl::with_cert_and_key("examples/assets/self_signed.crt", "examples/assets/key.pem").unwrap();
     let mut server = Nickel::new();
     server.get("**", middleware!("Hello World from HTTPS"));
+    
+    /*
+     * Hint: If you want to use the `listen_https` function in your own crate / module / project, you need to
+     * add `nickel/ssl` to the features section of your crate configuration, to get nickel compiled
+     * with ssl feature activated:
+     * 
+     * Cargo.toml >
+     *      [features]
+     *      ssl = ["nickel/ssl"]
+     *
+     * As you can see, to append `hyper/ssl` in the features section is obsolete, as hyper will get compiled with
+     * ssl feature activated via `nickel/ssl`.
+    */
     server.listen_https("127.0.0.1:6767", ssl);
 }
 


### PR DESCRIPTION
docs(https.rs): add hint for ssl feature compilation

Added hint to the https.rs example, where other users get in know about,
how they configure ssl in their Cargo.toml configuration correctly.

more information: issue: #354