### PR TITLE
feat(response): add Authorization<Bearer> as a `set`table type

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -413,6 +413,7 @@ mod modifier_impls {
         AcceptRanges,
         Allow,
         Authorization<Basic>,
+        Authorization<Bearer>,
         Authorization<String>,
         CacheControl,
         Cookie,


### PR DESCRIPTION
It looks like the Authorization<Bearer> type [just didn't exist](https://github.com/hyperium/hyper/commit/edf6ac2074d11694ded275807a66df3a8a8e33a6#diff-1af6105c3e0313f3d4e68615037d890b)
at the time the `set` method and `Modifiers` [were created](https://github.com/nickel-org/nickel.rs/commit/182517b89a232a715b2fde82efbe507cef96037e#diff-6cfc163228cc31bed4a7214fa0b69300), but it
has been present since hyper 0.6.0 and would be nice to include here.
