### PR TITLE
 feat(serde): add support for Serde serialization

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,4 +13,4 @@ install:
   - cargo -vV
 build: false
 test_script:
-  - cargo test --verbose --no-default-features
+  - cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ readme = "README.md"
 keywords = ["nickel", "server", "web", "express"]
 
 [features]
+default = ["rustc-serialize"]
 unstable = ["hyper/nightly", "compiletest_rs"]
+with-serde = ["serde", "serde_json", "mustache/serde"]
 ssl = ["hyper/ssl"]
 
 [dependencies]
@@ -22,10 +24,9 @@ time = "0.1"
 typemap = "0.3"
 plugin = "0.2"
 regex = "0.1"
-rustc-serialize = "0.3"
 log = "0.3"
 groupable = "0.2"
-mustache = "0.6"
+mustache = { git = "https://github.com/Ryman/rust-mustache.git", branch="serde", version = "*" }
 lazy_static = "0.1"
 modifier = "0.1"
 
@@ -35,6 +36,18 @@ default-features = false
 
 [dependencies.compiletest_rs]
 version = "0.1"
+optional = true
+
+[dependencies.rustc-serialize]
+version = "0.3"
+optional = true
+
+[dependencies.serde]
+version = "0.7"
+optional = true
+
+[dependencies.serde_json]
+version = "0.7"
 optional = true
 
 [[example]]

--- a/examples/integration_testing.rs
+++ b/examples/integration_testing.rs
@@ -94,13 +94,17 @@ impl ServerData {
     }
 }
 
-#[cfg_attr(not(feature = "with-serde"), derive(RustcEncodable, RustcDecodable))]
-struct Data { name: String, age: Option<u32> }
+#[cfg(not(feature = "with-serde"))]
+mod data {
+    #[derive(RustcEncodable, RustcDecodable)]
+    pub struct Data { pub name: String, pub age: Option<u32> }
+}
 
 #[cfg(feature = "with-serde")]
-mod serde_impls {
+mod data {
     use serde;
-    use super::Data;
+    
+    pub struct Data { pub name: String, pub age: Option<u32> }
     impl serde::Serialize for Data {
         fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
             where S: serde::Serializer
@@ -210,6 +214,8 @@ mod serde_impls {
         }
     }
 }
+
+use self::data::Data;
 
 fn main() {
     let port = env::var("PORT").map(|s| s.parse().unwrap()).unwrap_or(3000);

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -1,23 +1,170 @@
 #[macro_use] extern crate nickel;
+
+#[cfg(not(feature = "with-serde"))]
 extern crate rustc_serialize;
+#[cfg(feature = "with-serde")]
+extern crate serde_json;
+#[cfg(feature = "with-serde")]
+extern crate serde;
 
 use std::collections::BTreeMap;
 use nickel::status::StatusCode;
 use nickel::{Nickel, JsonBody, HttpRouter, MediaType};
-use rustc_serialize::json::{Json, ToJson};
 
-#[derive(RustcDecodable, RustcEncodable)]
+#[cfg(not(feature = "with-serde"))]
+mod json {
+    use rustc_serialize::json::{ ToJson, Json };
+
+    pub fn to_json<T: ToJson>(json: T) -> Json {
+        json.to_json()
+    }
+}
+#[cfg(feature = "with-serde")]
+mod json {
+    use serde;
+    use serde_json::{ self, Value };
+
+    pub fn to_json<T: serde::Serialize>(json: T) -> Value {
+        serde_json::to_value(&json)
+    }
+}
+
+use json::to_json;
+
+#[cfg_attr(not(feature = "with-serde"), derive(RustcDecodable, RustcEncodable))]
 struct Person {
     first_name: String,
     last_name:  String,
 }
 
-impl ToJson for Person {
-    fn to_json(&self) -> Json {
-        let mut map = BTreeMap::new();
-        map.insert("first_name".to_string(), self.first_name.to_json());
-        map.insert("last_name".to_string(), self.last_name.to_json());
-        Json::Object(map)
+#[cfg(not(feature = "with-serde"))]
+mod rustc_serialize_impls {
+    use std::collections::BTreeMap;
+    use rustc_serialize;
+    use super::Person;
+
+    impl rustc_serialize::json::ToJson for Person {
+        fn to_json(&self) -> rustc_serialize::json::Json {
+            let mut map = BTreeMap::new();
+            map.insert("first_name".to_string(), self.first_name.to_json());
+            map.insert("last_name".to_string(), self.last_name.to_json());
+            rustc_serialize::json::Json::Object(map)
+        }
+    }
+}
+
+#[cfg(feature = "with-serde")]
+mod serde_impls {
+    use serde;
+    use super::Person;
+
+    impl serde::Serialize for Person {
+        fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
+            where S: serde::Serializer
+        {
+            serializer.serialize_struct("Person", PersonMapVisitor {
+                value: self,
+                state: 0,
+            })
+        }
+    }
+
+    struct PersonMapVisitor<'a> {
+        value: &'a Person,
+        state: u8,
+    }
+
+    impl<'a> serde::ser::MapVisitor for PersonMapVisitor<'a> {
+        fn visit<S>(&mut self, serializer: &mut S) -> Result<Option<()>, S::Error>
+            where S: serde::Serializer
+        {
+            match self.state {
+                0 => {
+                    self.state += 1;
+                    Ok(Some(try!(serializer.serialize_struct_elt("first_name", &self.value.first_name))))
+                }
+                1 => {
+                    self.state += 1;
+                    Ok(Some(try!(serializer.serialize_struct_elt("last_name", &self.value.last_name))))
+                }
+                _ => {
+                    Ok(None)
+                }
+            }
+        }
+    }
+
+    enum PersonField {
+        FirstName,
+        LastName,
+    }
+
+    impl serde::Deserialize for PersonField {
+        fn deserialize<D>(deserializer: &mut D) -> Result<PersonField, D::Error>
+            where D: serde::de::Deserializer
+        {
+            struct PersonFieldVisitor;
+
+            impl serde::de::Visitor for PersonFieldVisitor {
+                type Value = PersonField;
+
+                fn visit_str<E>(&mut self, value: &str) -> Result<PersonField, E>
+                    where E: serde::de::Error
+                {
+                    match value {
+                        "first_name" => Ok(PersonField::FirstName),
+                        "last_name" => Ok(PersonField::LastName),
+                        _ => Err(serde::de::Error::custom("expected first_name or last_name")),
+                    }
+                }
+            }
+
+            deserializer.deserialize(PersonFieldVisitor)
+        }
+    }
+
+    impl serde::Deserialize for Person {
+        fn deserialize<D>(deserializer: &mut D) -> Result<Person, D::Error>
+            where D: serde::de::Deserializer
+        {
+            static FIELDS: &'static [&'static str] = &["first_name", "last_name"];
+            deserializer.deserialize_struct("Person", FIELDS, PersonVisitor)
+        }
+    }
+
+    struct PersonVisitor;
+
+    impl serde::de::Visitor for PersonVisitor {
+        type Value = Person;
+
+        fn visit_map<V>(&mut self, mut visitor: V) -> Result<Person, V::Error>
+            where V: serde::de::MapVisitor
+        {
+            let mut first_name = None;
+            let mut last_name = None;
+
+            loop {
+                match try!(visitor.visit_key()) {
+                    Some(PersonField::FirstName) => { first_name = Some(try!(visitor.visit_value())); }
+                    Some(PersonField::LastName) => { last_name = Some(try!(visitor.visit_value())); }
+                    None => { break; }
+                }
+            }
+
+            let first_name = match first_name {
+                Some(first_name) => first_name,
+                None => try!(visitor.missing_field("first_name")),
+            };
+
+            let last_name = match last_name {
+                Some(last_name) => last_name,
+                None => try!(visitor.missing_field("last_name")),
+            };
+
+            try!(visitor.end());
+
+            Ok(Person{ first_name: first_name, last_name: last_name })
+        }
     }
 }
 
@@ -43,7 +190,7 @@ fn main() {
             first_name: first_name.to_string(),
             last_name: last_name.to_string(),
         };
-        person.to_json()
+        to_json(person)
     });
 
     // go to http://localhost:6767/content-type to see this route in action

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -7,7 +7,6 @@ extern crate serde_json;
 #[cfg(feature = "with-serde")]
 extern crate serde;
 
-use std::collections::BTreeMap;
 use nickel::status::StatusCode;
 use nickel::{Nickel, JsonBody, HttpRouter, MediaType};
 
@@ -31,18 +30,16 @@ mod json {
 
 use json::to_json;
 
-#[cfg_attr(not(feature = "with-serde"), derive(RustcDecodable, RustcEncodable))]
-struct Person {
-    first_name: String,
-    last_name:  String,
-}
-
 #[cfg(not(feature = "with-serde"))]
-mod rustc_serialize_impls {
+mod person {
     use std::collections::BTreeMap;
     use rustc_serialize;
-    use super::Person;
-
+    
+    #[derive(RustcEncodable, RustcDecodable)]
+    pub struct Person {
+        pub first_name: String,
+        pub last_name:  String,
+    }
     impl rustc_serialize::json::ToJson for Person {
         fn to_json(&self) -> rustc_serialize::json::Json {
             let mut map = BTreeMap::new();
@@ -54,10 +51,13 @@ mod rustc_serialize_impls {
 }
 
 #[cfg(feature = "with-serde")]
-mod serde_impls {
+mod person {
     use serde;
-    use super::Person;
 
+    pub struct Person {
+        pub first_name: String,
+        pub last_name:  String,
+    }
     impl serde::Serialize for Person {
         fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
             where S: serde::Serializer
@@ -167,6 +167,8 @@ mod serde_impls {
         }
     }
 }
+
+use self::person::Person;
 
 fn main() {
     let mut server = Nickel::new();

--- a/examples/macro_example.rs
+++ b/examples/macro_example.rs
@@ -18,19 +18,17 @@ use nickel::{
 use regex::Regex;
 use hyper::header::Location;
 
-#[cfg_attr(not(feature = "with-serde"), derive(RustcDecodable, RustcEncodable))]
-struct Person {
-    firstname: String,
-    lastname:  String,
-}
-
 #[cfg(not(feature = "with-serde"))]
-mod rustc_serialize_impls {
+mod person {
     use std::collections::BTreeMap;
     use rustc_serialize;
     use rustc_serialize::json::{ ToJson, Json };
-    use super::Person;
-
+    
+    #[derive(RustcEncodable, RustcDecodable)]
+    pub struct Person {
+        pub firstname: String,
+        pub lastname:  String,
+    }
     impl ToJson for Person {
         fn to_json(&self) -> Json {
             let mut map = BTreeMap::new();
@@ -42,10 +40,13 @@ mod rustc_serialize_impls {
 }
 
 #[cfg(feature = "with-serde")]
-mod serde_impls {
+mod person {
     use serde;
-    use super::Person;
 
+    pub struct Person {
+        pub firstname: String,
+        pub lastname:  String,
+    }
     impl serde::Serialize for Person {
         fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
             where S: serde::Serializer
@@ -155,6 +156,8 @@ mod serde_impls {
         }
     }
 }
+
+use self::person::Person;
 
 //this is an example middleware function that just logs each request
 fn logger<'a, D>(request: &mut Request<D>, response: Response<'a, D>) -> MiddlewareResult<'a, D> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,13 @@
 #![doc(test(attr(deny(warnings))))]
 
-extern crate time;
+#[cfg(not(feature = "with-serde"))]
 extern crate rustc_serialize as serialize;
+#[cfg(feature = "with-serde")]
+extern crate serde_json;
+#[cfg(feature = "with-serde")]
+extern crate serde;
+
+extern crate time;
 extern crate hyper;
 extern crate regex;
 extern crate typemap;

--- a/src/response.rs
+++ b/src/response.rs
@@ -4,7 +4,6 @@ use std::sync::RwLock;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::path::Path;
-use serialize::Encodable;
 use hyper::status::StatusCode;
 use hyper::server::Response as HyperResponse;
 use hyper::header::{
@@ -22,6 +21,11 @@ use {NickelError, Halt, MiddlewareResult, Responder, Action};
 use modifier::Modifier;
 use plugin::{Extensible, Pluggable};
 use typemap::TypeMap;
+
+#[cfg(not(feature = "with-serde"))]
+use serialize::Encodable;
+#[cfg(feature = "with-serde")]
+use serde::Serialize as Encodable;
 
 pub type TemplateCache = RwLock<HashMap<String, Template>>;
 

--- a/tests/example_tests.rs
+++ b/tests/example_tests.rs
@@ -1,4 +1,10 @@
+#[cfg(not(feature = "with-serde"))]
 extern crate rustc_serialize;
+#[cfg(feature = "with-serde")]
+extern crate serde_json;
+#[cfg(feature = "with-serde")]
+extern crate serde;
+
 extern crate hyper;
 // HACK: integration_testing example refers to `nickel::foo`
 // and this import helps that resolve rather than requiring `self::nickel::foo`


### PR DESCRIPTION
Closes #345 

This is a first-pass attempt at adding support for `serde` serialisation.

The feature is called `with-serde`, so to use call:

```
rustup run stable cargo build --features with-serde --no-default-features
```

`rustc_serialize` is the default choice, so this shouldn't break existing implementations by default.

`rustc_serialize` has served us well, but it's clear that `serde` is the framework to support in the longterm. I wouldn't expect this feature to land for a little while yet; `serde` is working through a new breaking release which would make sense to support (most of that ugly manual serialisation in the examples will go away), but will also need to be updated in the [PR](https://github.com/nickel-org/rust-mustache/pull/40) for `mustache`.

A few things on my mind:
- Serialising to `serde_json::Value`, and then from `Value` to a `String` when building a response seems wacky. I'm thinking of adding a struct `Json<'a T: Serialize>(&'a T)` (could get away without the borrow if need be) that can implement `Responder`, to set mime properly, but avoid that extra hop.
- Do the cfg attributes better now that I have a bit of a better idea how `nickel` works.
- Make the cruft I've introduced to the example tests a bit nicer (it's not really representative of how people would use it anymore, because nobody is going to make their app support both serialisation frameworks). Some feedback here would be great!
