### PR TITLE
fix: don't panic with non-UTF8 environment

### DIFF
--- a/src/nickel.rs
+++ b/src/nickel.rs
@@ -211,7 +211,7 @@ impl<D: Sync + Send + 'static> Nickel<D> {
 
         let server = Server::new(self.middleware_stack, self.data);
 
-        let is_test_harness = env::vars().any(|(ref k, _)| k == "NICKEL_TEST_HARNESS");
+        let is_test_harness = env::var_os("NICKEL_TEST_HARNESS").is_some();
 
         let listener = if is_test_harness {
             // If we're under a test harness, we'll pass zero to get assigned a random
@@ -285,7 +285,7 @@ impl<D: Sync + Send + 'static> Nickel<D> {
 
         let server = Server::new(self.middleware_stack, self.data);
 
-        let is_test_harness = env::vars().any(|(ref k, _)| k == "NICKEL_TEST_HARNESS");
+        let is_test_harness = env::var_os("NICKEL_TEST_HARNESS").is_some();
 
         let listener = if is_test_harness {
             // If we're under a test harness, we'll pass zero to get assigned a random


### PR DESCRIPTION
Nickel::listen() and Nickel::listen_https() check for the presence
of $NICKEL_TEST_HARNESS in a way which causes a panic if any value
in the environment contains a non-UTF8 string. This patch fixes
the check.

Fixes #379
