### PR TITLE
compiletest was updated to 0.2.x to reflect a change in rust nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ version = "0.9"
 default-features = false
 
 [dependencies.compiletest_rs]
-version = "0.1"
+version = "0.2"
 optional = true
 
 [[example]]


### PR DESCRIPTION
Update compiletest to 0.2.x. This resolves the feature 'unstable' being unable to compile on the latest nightly.

```
Compiling compiletest_rs v0.1.3
error[E0063]: missing field `test_threads` in initializer of `test::TestOpts`
   --> /home/lholden/.cargo/registry/src/github.com-1ecc6299db9ec823/compiletest_rs-0.1.3/src/compiletest.rs:116:5
    |
116 |     test::TestOpts {
    |     ^^^^^^^^^^^^^^

error: aborting due to previous error

error: Could not compile `compiletest_rs`.
```
