### PR TITLE
doc(Readme): Fix little typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [nickel.rs](http://nickel.rs) is a simple and lightweight foundation for web applications written in Rust. Its API is inspired by the popular express framework for JavaScript.
 
-##Hello world
+## Hello world
 
 ```rust,no_run
 #[macro_use] extern crate nickel;
@@ -45,7 +45,7 @@ You can then compile this using *Cargo build* and run it using *Cargo run*. Afte
 
 More examples can be found [in the examples directory](/examples/) and the full documentation can be [found here](http://docs.nickel.rs).
 
-##Contributing
+## Contributing
 
 [nickel.rs](http://nickel.rs) is a community effort. We welcome new contributors with open arms. Please read the [contributing guide here](/contributing.md) first.
 


### PR DESCRIPTION
Without a white space the between `#` and the header text, the rendering on github is not working.