### PR TITLE
doc(response): remove mistaken comment line in set_header doc

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -166,7 +166,6 @@ impl<'a, D> Response<'a, D, Fresh> {
     /// Sets the header if not already set.
     ///
     /// If the header is not set then `f` will be called.
-    /// Renders the given template bound with the given data.
     ///
     /// # Examples
     /// ```{rust}


### PR DESCRIPTION
doc-comment line seems to have been errornously added and actually belongs to `render` (which is right below in the file) instead of `set_header` where it was removed.