### PR TITLE
fix(examples): Fix examples triggering issue #399

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,5 +38,4 @@ env:
   global:
     secure: nPXTdkq9TK4LmqJWqB4jxscDG1mnqJzO0UX5ni+oC0SohjgBxdWjbvJ8Kthk3c8Qg/2zGlCryuT1lV4TcD3jF86MHlRlXsO3G8fCbEGdLLzppbV0A2VnEw1knhv2mfUhxA8hsFJE2ncT5qeOVyQ6N3PAMGoYkdhhbD9N/9EWuqs=
   matrix:
-    - FEATURES="--features ssl"
     - FEATURES=""

--- a/examples/form_data/form_data.rs
+++ b/examples/form_data/form_data.rs
@@ -1,30 +1,34 @@
 #[macro_use] extern crate nickel;
-use nickel::{Nickel, HttpRouter, FormBody};
+use nickel::{Nickel, HttpRouter, FormBody, Request, Response, MiddlewareResult};
 use std::collections::HashMap;
+
+fn root<'mw, 'conn>(_req: &mut Request<'mw, 'conn>, res: Response<'mw>) -> MiddlewareResult<'mw> {
+    let mut data = HashMap::new();
+    data.insert("title","Contact");
+
+    return res.render("examples/form_data/views/contact.html", &data)
+}
+
+fn confirmation<'mw, 'conn>(req: &mut Request<'mw, 'conn>, res: Response<'mw>) -> MiddlewareResult<'mw> {
+    let form_data = try_with!(res, req.form_body());
+
+    println!("{:?}", form_data);
+
+    let mut data = HashMap::new();
+    data.insert("title", "Confirmation");
+    data.insert("firstname", form_data.get("firstname").unwrap_or("First name?"));
+    data.insert("lastname", form_data.get("lastname").unwrap_or("Last name?"));
+    data.insert("phone", form_data.get("phone").unwrap_or("Phone?"));
+    data.insert("email", form_data.get("email").unwrap_or("Email?"));
+    return res.render("examples/form_data/views/confirmation.html", &data)
+}
 
 fn main() {
     let mut server = Nickel::new();
 
-    server.get("/", middleware! { |_, res|
-        let mut data = HashMap::new();
-        data.insert("title","Contact");
+    server.get("/", root);
 
-        return res.render("examples/form_data/views/contact.html", &data)
-    });
-
-    server.post("/confirmation", middleware!{ |req, res|
-        let form_data = try_with!(res, req.form_body());
-
-        println!("{:?}", form_data);
-
-        let mut data = HashMap::new();
-        data.insert("title", "Confirmation");
-        data.insert("firstname", form_data.get("firstname").unwrap_or("First name?"));
-        data.insert("lastname", form_data.get("lastname").unwrap_or("Last name?"));
-        data.insert("phone", form_data.get("phone").unwrap_or("Phone?"));
-        data.insert("email", form_data.get("email").unwrap_or("Email?"));
-        return res.render("examples/form_data/views/confirmation.html", &data)
-    });
+    server.post("/confirmation", confirmation);
 
     server.listen("0.0.0.0:8080").unwrap();
 }

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,4 +1,4 @@
-#[macro_use] extern crate nickel;
+extern crate nickel;
 
 use nickel::{Nickel, HttpRouter, Request, Response, MiddlewareResult};
 

--- a/examples/macro_example.rs
+++ b/examples/macro_example.rs
@@ -7,7 +7,7 @@ use std::io::Write;
 use nickel::status::StatusCode::{self, NotFound};
 use nickel::{
     Nickel, NickelError, Continue, Halt, Request, Response, MediaType,
-    QueryString, JsonBody, StaticFilesHandler, MiddlewareResult, HttpRouter, Action
+    QueryString, JsonBody, StaticFilesHandler, MiddlewareResult, Action
 };
 use regex::Regex;
 use hyper::header::Location;

--- a/examples/no_macro_custom_data.rs
+++ b/examples/no_macro_custom_data.rs
@@ -1,4 +1,4 @@
-#[macro_use] extern crate nickel;
+extern crate nickel;
 
 use nickel::{Nickel, HttpRouter, Request, Response, MiddlewareResult};
 
@@ -16,5 +16,5 @@ fn main() {
 
     let mut server = Nickel::with_data(my_config);
     server.get("**", greeter);
-    server.listen("127.0.0.1:6767");
+    server.listen("127.0.0.1:6767").unwrap();
 }

--- a/examples/static_files.rs
+++ b/examples/static_files.rs
@@ -1,4 +1,4 @@
-#[macro_use] extern crate nickel;
+extern crate nickel;
 
 use nickel::{Nickel, StaticFilesHandler};
 

--- a/examples/template.rs
+++ b/examples/template.rs
@@ -1,18 +1,18 @@
-#[macro_use] extern crate nickel;
+extern crate nickel;
 
-use nickel::{Nickel, HttpRouter};
+use nickel::{Nickel, HttpRouter, Request, Response, MiddlewareResult};
 use std::collections::HashMap;
+
+fn render<'mw, 'conn>(_req: &mut Request<'mw, 'conn>, res: Response<'mw>) -> MiddlewareResult<'mw> {
+    let mut data = HashMap::<&str, &str>::new();
+    data.insert("name", "user");
+    return res.render("examples/assets/template.tpl", &data)
+}
 
 fn main() {
     let mut server = Nickel::new();
 
-    // * NOTE *
-    // This example is deprecated, you should use nickel_mustache from crates.io
-    server.get("/", middleware! { |_, res|
-        let mut data = HashMap::<&str, &str>::new();
-        data.insert("name", "user");
-        return res.render("examples/assets/template.tpl", &data)
-    });
+    server.get("/", render);
 
     server.listen("127.0.0.1:6767").unwrap();
 }

--- a/src/body_parser.rs
+++ b/src/body_parser.rs
@@ -61,7 +61,7 @@ pub trait FormBody {
     ///     let mut server = Nickel::new();
     ///     server.post("/a", middleware! { |req, res|
     ///         let form_body = try_with!(res, req.form_body());
-    ///         return res.send(format!("Post: {:?}", form_body))
+    ///         format!("Post: {:?}", form_body)
     ///     });
     /// }
     /// ```

--- a/src/extensions/request.rs
+++ b/src/extensions/request.rs
@@ -10,17 +10,19 @@ impl<'mw, 'server, D> Referer for Request<'mw, 'server, D> {
     ///
     /// # Examples
     /// ```{rust}
-    /// #[macro_use] extern crate nickel;
+    /// extern crate nickel;
     ///
-    /// use nickel::{Nickel, HttpRouter};
+    /// use nickel::{Nickel, HttpRouter, Request, Response, MiddlewareResult};
     /// use nickel::extensions::{Referer, Redirect};
+    ///
+    /// fn referer<'mw, 'conn>(req: &mut Request<'mw, 'conn>, res: Response<'mw>) -> MiddlewareResult<'mw> {
+    ///     let back = req.referer().unwrap_or("http://nickel-org.github.io/");
+    ///     return res.redirect(back)
+    /// }
     ///
     /// fn main() {
     ///     let mut server = Nickel::new();
-    ///     server.get("/a", middleware! { |req, res|
-    ///         let back = req.referer().unwrap_or("http://nickel.rs");
-    ///         return res.redirect(back)
-    ///     });
+    ///     server.get("/a", referer);
     /// }
     /// ```
     fn referer(&self) -> Option<&str> {

--- a/src/extensions/response.rs
+++ b/src/extensions/response.rs
@@ -9,16 +9,18 @@ pub trait Redirect: Sized {
     ///
     /// # Examples
     /// ```{rust}
-    /// #[macro_use] extern crate nickel;
+    /// extern crate nickel;
     ///
-    /// use nickel::{Nickel, HttpRouter};
+    /// use nickel::{Nickel, HttpRouter, Request, Response, MiddlewareResult};
     /// use nickel::extensions::Redirect;
+    ///
+    /// fn redirect<'mw, 'conn>(_: &mut Request<'mw, 'conn>, res: Response<'mw>) -> MiddlewareResult<'mw> {
+    ///     return res.redirect("http://nickel.rs")
+    /// }
     ///
     /// fn main() {
     ///     let mut server = Nickel::new();
-    ///     server.get("/a", middleware! { |_, res|
-    ///         return res.redirect("http://nickel.rs")
-    ///     });
+    ///     server.get("/a", redirect);
     /// }
     /// ```
     fn redirect<T>(self, target: T) -> Self::Result
@@ -35,6 +37,8 @@ pub trait Redirect: Sized {
     where T: Into<String>;
 }
 
+// Todo: rework this to return a Responder so it will work with the
+// middleware macro
 impl<'a, D> Redirect for Response<'a, D> {
     type Result = MiddlewareResult<'a, D>;
 

--- a/src/macros/middleware.rs
+++ b/src/macros/middleware.rs
@@ -4,6 +4,19 @@
 /// In future, the macro should hopefully be able to be removed while
 /// having minimal changes to the closure's code.
 ///
+/// # Limitations
+///
+/// The body of the `middleware!` macro needs to return something
+/// implementing `Responder`. Some older examples had bodies that
+/// would return a `MiddlewareResult`, but this was exploiting an
+/// unsoundness in the Rust compiler that has since been
+/// tightened. See discussion at
+/// https://github.com/nickel-org/nickel.rs/issues/399.
+///
+/// Due to the way the macro is expanded, exiting the body early with
+/// a return statement will most likely fail with a cryptic error
+/// message. See https://github.com/nickel-org/nickel.rs/issues/389.
+///
 /// # Examples
 /// ```rust,no_run
 /// # #[macro_use] extern crate nickel;

--- a/src/query_string.rs
+++ b/src/query_string.rs
@@ -28,7 +28,7 @@ pub trait QueryString {
     ///     let mut server = Nickel::new();
     ///     server.get("/a", middleware! { |req, res|
     ///         let query = req.query();
-    ///         return res.send(format!("Query: {:?}", query))
+    ///         format!("Query: {:?}", query)
     ///     });
     /// }
     /// ```

--- a/src/response.rs
+++ b/src/response.rs
@@ -15,7 +15,7 @@ use time;
 use mimes::MediaType;
 use mustache;
 use mustache::Template;
-use std::io::{self, Read, Write, copy};
+use std::io::{self, Write, copy};
 use std::fs::File;
 use std::any::Any;
 use {NickelError, Halt, MiddlewareResult, Responder, Action};

--- a/src/urlencoded.rs
+++ b/src/urlencoded.rs
@@ -2,7 +2,7 @@ use groupable::Groupable;
 use hyper::uri::RequestUri;
 use hyper::uri::RequestUri::{Star, AbsoluteUri, AbsolutePath, Authority};
 use std::collections::HashMap;
-use url::{form_urlencoded, Url};
+use url::form_urlencoded;
 
 type QueryStore = HashMap<String, Vec<String>>;
 


### PR DESCRIPTION
Fix the examples that were returning MiddlewareResults in the
middlware! macro. A couple could be changed to return a Responder, but
most needed to be reimplemented as seperate functions.

Updated the middleware! macro documentaion to note the limitations
from issues #399 and #389.