### PR TITLE
feat(templates): Support reloading templates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub use nickel_error::NickelError;
 pub use mimes::MediaType;
 pub use responder::Responder;
 pub use server::ListeningServer;
+pub use template_cache::{ReloadPolicy, TemplateCache};
 
 #[macro_use] pub mod macros;
 
@@ -50,6 +51,7 @@ mod urlencoded;
 mod nickel_error;
 mod default_error_handler;
 pub mod extensions;
+pub mod template_cache;
 
 pub mod status {
     pub use hyper::status::StatusCode;

--- a/src/nickel.rs
+++ b/src/nickel.rs
@@ -5,6 +5,7 @@ use std::error::Error as StdError;
 use router::{Router, HttpRouter, Matcher};
 use middleware::{MiddlewareStack, Middleware, ErrorHandler};
 use server::{Server, ListeningServer};
+use template_cache::ReloadPolicy;
 use hyper::method::Method;
 use hyper::net::SslServer;
 use hyper::status::StatusCode;
@@ -30,6 +31,7 @@ use default_error_handler::DefaultErrorHandler;
 pub struct Options {
     output_on_listen: bool,
     thread_count: Option<usize>,
+    reload_policy: ReloadPolicy,
 }
 
 impl Options {
@@ -49,6 +51,12 @@ impl Options {
         self.thread_count = thread_count;
         self
     }
+
+    /// The TemplateCache reload policy. Defaults to ReloadPolicy::Never.
+    pub fn reload_policy(mut self, reload_policy: ReloadPolicy) -> Self {
+        self.reload_policy = reload_policy;
+        self
+    }
 }
 
 impl Default for Options {
@@ -56,6 +64,7 @@ impl Default for Options {
         Options {
             output_on_listen: true,
             thread_count: None,
+            reload_policy: ReloadPolicy::Never,
         }
     }
 }
@@ -85,11 +94,17 @@ impl Nickel<()> {
     pub fn new() -> Nickel<()> {
         Nickel::with_data(())
     }
+
+    /// Creates and instance of Nickel with custom Options.
+    pub fn with_options(options: Options) -> Nickel<()> {
+        Nickel::with_data_and_options((), options)
+    }
 }
 
 impl<D: Sync + Send + 'static> Nickel<D> {
-    /// Creates an instance of Nickel with default error handling and custom data.
-    pub fn with_data(data: D) -> Nickel<D> {
+    /// Creates an instance of Nickel with default error handling,
+    /// default Ooptions, and custom data.
+    pub fn with_data_and_options(data: D, options: Options) -> Nickel<D> {
         let mut middleware_stack = MiddlewareStack::new();
 
         // Hook up the default error handler by default. Users are
@@ -99,11 +114,17 @@ impl<D: Sync + Send + 'static> Nickel<D> {
 
         Nickel {
             middleware_stack: middleware_stack,
-            options: Options::default(),
+            options: options,
             data: data,
             // Default value from nginx
             keep_alive_timeout: Some(Duration::from_secs(75))
         }
+    }
+
+    /// Creates an instance of Nickel with default error handling,
+    /// default Ooptions, and custom data.
+    pub fn with_data(data: D) -> Nickel<D> {
+        Nickel::with_data_and_options(data, Options::default())
     }
 
     /// Registers a middleware handler which will be invoked among other middleware
@@ -209,7 +230,7 @@ impl<D: Sync + Send + 'static> Nickel<D> {
             (StatusCode::NotFound, "File Not Found")
         });
 
-        let server = Server::new(self.middleware_stack, self.data);
+        let server = Server::new(self.middleware_stack, self.options.reload_policy, self.data);
 
         let is_test_harness = env::var_os("NICKEL_TEST_HARNESS").is_some();
 
@@ -283,7 +304,7 @@ impl<D: Sync + Send + 'static> Nickel<D> {
             (StatusCode::NotFound, "File Not Found")
         });
 
-        let server = Server::new(self.middleware_stack, self.data);
+        let server = Server::new(self.middleware_stack, self.options.reload_policy, self.data);
 
         let is_test_harness = env::var_os("NICKEL_TEST_HARNESS").is_some();
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,6 +1,5 @@
 use std::net::{SocketAddr, ToSocketAddrs};
-use std::sync::{Arc, RwLock};
-use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 use hyper::Result as HttpResult;
 use hyper::server::{Request, Response, Handler, Listening};
@@ -10,10 +9,11 @@ use hyper::net::SslServer;
 use middleware::MiddlewareStack;
 use request;
 use response;
+use template_cache::{ReloadPolicy, TemplateCache};
 
 pub struct Server<D> {
     middleware_stack: MiddlewareStack<D>,
-    templates: response::TemplateCache,
+    templates: TemplateCache,
     shared_data: D,
 }
 
@@ -34,10 +34,10 @@ impl<D: Sync + Send + 'static> Handler for ArcServer<D> {
 }
 
 impl<D: Sync + Send + 'static> Server<D> {
-    pub fn new(middleware_stack: MiddlewareStack<D>, data: D) -> Server<D> {
+    pub fn new(middleware_stack: MiddlewareStack<D>, reload_policy: ReloadPolicy, data: D) -> Server<D> {
         Server {
             middleware_stack: middleware_stack,
-            templates: RwLock::new(HashMap::new()),
+            templates: TemplateCache::with_policy(reload_policy),
             shared_data: data
         }
     }

--- a/src/template_cache.rs
+++ b/src/template_cache.rs
@@ -1,0 +1,150 @@
+use mustache::{Error, Template, compile_path};
+use serialize::Encodable;
+use std::collections::HashMap;
+use std::fs::metadata;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::RwLock;
+use std::time::{Duration, SystemTime};
+
+
+struct TemplateEntry {
+    template: Template,       // Compiled template
+    mtime: SystemTime,        // mtime of parsed template file
+    last_checked: SystemTime, // last time the template file mtime was checked
+}
+
+impl TemplateEntry {
+    // Loads a template from the given filename
+    fn from_template_file<P: AsRef<Path>>(filename: P) -> Result<TemplateEntry, Error> {
+        let path = filename.as_ref();
+        let template = compile_path(path)?;
+        let attr = metadata(path)?;
+        Ok(TemplateEntry{template: template, mtime: attr.modified()?, last_checked: SystemTime::now()})
+    }
+
+    // render the tempate with the given data
+    fn render<W, D>(&self, writer: &mut W, data: &D) -> Result<(), Error>
+        where W: Write, D: Encodable {
+        self.template.render(writer, data)
+    }
+}
+
+/// ReloadPolicy controls how often the modification time of template
+/// file is checked. Checks take place only when rendering the
+/// template.
+pub enum ReloadPolicy {
+    /// Never check for changes. Once loaded, templates will not
+    /// change unless one of TemplateCache::clear or
+    /// TemplateCache::reload_template are called, or the server is
+    /// restarted.
+    Never,
+    /// Check after a period of time. For example, with a duration of
+    /// 30 min, the template will be checked no more than once every
+    /// 30 min.
+    Periodic(Duration),
+    /// Check every time the template is rendered.
+    Always,
+}
+
+/// Cache of compiled mustache templates
+pub struct TemplateCache {
+    cache: RwLock<HashMap<PathBuf, TemplateEntry>>,
+    reload_policy: ReloadPolicy,
+}
+
+impl TemplateCache {
+    /// Create a TemplateCache with the specified reload policy
+    pub fn with_policy(policy: ReloadPolicy) -> TemplateCache {
+        TemplateCache{cache: RwLock::new(HashMap::new()), reload_policy: policy}
+    }
+
+    /// Remove all cache entries
+    pub fn clear(&self) {
+        let mut c = self.cache.write().expect("TemplateCache::clear - cache poisoned");
+        c.clear();
+    }
+
+    /// Force a reload of a template into the cache
+    pub fn reload_template<P>(&self, path: P) -> Result<(), Error>
+        where P: AsRef<Path> {
+
+        let mut c = self.cache.write().expect("TemplateCache::reload_template - cache poisoned");
+        let template = TemplateEntry::from_template_file(&path)?;
+        c.insert(path.as_ref().to_path_buf(), template);
+        Ok(())
+    }
+
+    // Tries to render the template with the given data. This method
+    // only needs a read lock. Returns:
+    //
+    //   * Ok(true)  - successfully rendered
+    //
+    //   * Ok(false) - template needs loading, either it was never
+    //                 loaded, or it is outdated
+    //
+    //   * Err(e) - mustache error
+    fn try_render_template<P, W, D>(&self, path: P, writer: &mut W, data: &D) -> Result<bool, Error>
+        where P: AsRef<Path>, W: Write, D: Encodable {
+
+        let c = self.cache.read().expect("TemplateCache::try_render_template - cache poisoned");
+        if let Some(template) = c.get(&path.as_ref().to_path_buf()) {
+            let check_mtime = match self.reload_policy {
+                ReloadPolicy::Never => false,
+                ReloadPolicy::Always => true,
+                ReloadPolicy::Periodic(period) => {
+                    let now = SystemTime::now();
+                    if let Ok(duration) = now.duration_since(template.last_checked) {
+                        duration > period
+                    } else {
+                        // wierdness, we went back in time, force reload
+                        true
+                    }
+                }
+            };
+            if check_mtime {
+                let mtime = metadata(path)?.modified()?;
+                if mtime > template.mtime {
+                    return Ok(false);
+                }
+            }
+            template.render(writer, data)?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    // Load the template from disk, compile it, store the compiled
+    // template in cache, and render. This needs a write lock.
+    fn load_render_template<P, W, D>(&self, path: P, writer: &mut W, data: &D) -> Result<(), Error>
+        where P: AsRef<Path>, W: Write, D: Encodable {
+
+        let mut c = self.cache.write().expect("TemplateCache::load_render_template - cache poisoned");
+        let template = TemplateEntry::from_template_file(&path)?;
+        template.render(writer, data)?;
+        c.insert(path.as_ref().to_path_buf(), template);
+        Ok(())
+    }
+
+    /// Render the template at `path` to `writer` with
+    /// `data`. Templates will be reloaded if necessary according to
+    /// the reload policy.
+    pub fn render<P, W, D>(&self, path: P, writer: &mut W, data: &D) -> Result<(), Error>
+        where P: AsRef<Path>, W: Write, D: Encodable {
+        let rendered = match self.try_render_template(&path, writer, data) {
+            Ok(r) => r,
+            Err(e) => {
+                // Previously compiled template failed to render. Log
+                // an error and force a reload.
+                error!("Template render error: {:?}", e);
+                false
+            },
+        };
+        if !rendered {
+            self.load_render_template(&path, writer, data)
+        } else {
+            Ok(())
+        }
+    }
+}


### PR DESCRIPTION
Change TemplateCache to be a struct to add support for a variety of
ways to refresh compiled mustache templates.

* Templates can be explicitly reloaded with the TemplateCache::clear
  and TemplateCache::reload_template methods.

* ReloadPolicy can control automatic reloading when templates are
  rendered. The default of ReloadPolicy::Never is the previous
  behavior.

To support this, two new Nickel contructor methods were added to take
a nickel::Options struct.