### PR TITLE
Working cors examples

### DIFF
--- a/examples/enable_cors_header_set_issue.rs
+++ b/examples/enable_cors_header_set_issue.rs
@@ -1,6 +1,4 @@
 #[macro_use] extern crate nickel;
-extern crate hyper;
-
 use nickel::{Nickel, HttpRouter, Request, Response, MiddlewareResult};
 
 fn enable_cors<'mw>(_req: &mut Request, mut res: Response<'mw>) -> MiddlewareResult<'mw> {

--- a/examples/enable_cors_header_set_issue.rs
+++ b/examples/enable_cors_header_set_issue.rs
@@ -2,20 +2,12 @@
 extern crate hyper;
 
 use nickel::{Nickel, HttpRouter, Request, Response, MiddlewareResult};
-use hyper::header::{AccessControlAllowOrigin, AccessControlAllowHeaders};
 
 fn enable_cors<'mw>(_req: &mut Request, mut res: Response<'mw>) -> MiddlewareResult<'mw> {
     // Set appropriate headers
-    res.set(AccessControlAllowOrigin::Any);
-    res.set(AccessControlAllowHeaders(vec![
-        // Hyper uses the `unicase::Unicase` type to ensure comparisons are done
-        // case-insensitively. Here, we use `into()` to convert to one from a `&str`
-        // so that we don't have to import the type ourselves.
-        "Origin".into(),
-        "X-Requested-With".into(),
-        "Content-Type".into(),
-        "Accept".into(),
-    ]));
+    res.headers_mut().set_raw("Access-Control-Allow-Origin", vec![b"*".to_vec()]);
+    res.headers_mut().set_raw("Access-Control-Allow-Methods", vec![b"*".to_vec()]);
+    res.headers_mut().set_raw("Access-Control-Allow-Headers", vec![b"Origin, X-Requested-With, Content-Type, Accept".to_vec()]);
 
     // Pass control to the next middleware
     res.next_middleware()


### PR DESCRIPTION
I've added the `options` endpoint in order to enable preflight requests and also created a new example using manual setting of the headers to avoid issue mentioned in #365 & #324.