### PR TITLE
fix contributing.md formatting

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -8,25 +8,25 @@ Make sure to follow this [commit message convention](https://github.com/conventi
 
 The easiest way to get started is to get nickel running and play around with it. Let's do that real quick!
 
-##Clone the repository
+## Clone the repository
 
 ```shell
 git clone https://github.com/nickel-org/nickel.git
 ```
 
-##Build nickel
+## Build nickel
 
 ```shell
 cargo build --release
 ```
 
-##Run the tests
+## Run the tests
 
 ```shell
 cargo test
 ```
 
-##Run the example
+## Run the example
 
 ```shell
 cargo run --example example


### PR DESCRIPTION
This adds a space before headers in [contributing.md](https://github.com/nickel-org/nickel.rs/blob/master/contributing.md). Currently the headers don't have a space so they look like this:
##HeaderExample
The header should have a space in between the "##" and the text like this:
## Header Example