### PR TITLE
fix(static_file_handler): Support for blank spaces and percent encodi…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ serde_json = "1.0"
 time = "0.1"
 typemap = "0.3"
 url = "1.0"
+percent-encoding = "1.0.0"
 
 [dev-dependencies]
 serde_derive = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ extern crate url;
 extern crate mustache;
 extern crate groupable;
 extern crate modifier;
+extern crate percent_encoding;
 
 #[macro_use] extern crate log;
 #[macro_use] extern crate lazy_static;

--- a/src/static_files_handler.rs
+++ b/src/static_files_handler.rs
@@ -45,13 +45,15 @@ impl StaticFilesHandler {
         }
     }
 
-    fn extract_path<'a, D>(&self, req: &'a mut Request<D>) -> Option<&'a str> {
+    fn extract_path<'a, D>(&self, req: &'a mut Request<D>) -> Option<String> {
         req.path_without_query().map(|path| {
-            debug!("{:?} {:?}{:?}", req.origin.method, self.root_path.display(), path);
+            let percent_decoded_path = percent_encoding::percent_decode(path.as_bytes()).decode_utf8().unwrap();
+
+            debug!("{:?} {:?}{:?}", req.origin.method, self.root_path.display(), percent_decoded_path);
 
             match path {
-                "/" => "index.html",
-                path => &path[1..],
+                "/" => String::from("index.html"),
+                path => percent_decoded_path[1..].to_string(),
             }
         })
     }


### PR DESCRIPTION
# Summary
Adds handling for whitespaces in url for static files handler. 

# Issue
#405 

# Note
Im really new at Rust, and even more with ownership and low level memory handling, so probably i've made some mistakes in the way i changed this to a String. I'm more than open to hear suggestions on how to do this any better.
Fix inspired by https://github.com/lawliet89/nickel.rs/commit/f1c03e27c47366c974322e9db2904edd0ffcb9de 