### PR TITLE
chore(*): update dependencies and Rust edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 
 name = "nickel"
-version = "0.12.0"
+version = "0.12.1"
 authors = [ "Christoph Burgdorf <christoph@thoughtram.io>",
             "Kevin Butler <haqkrs@gmail.com>",
             "Simon Persson <simon@flaskpost.org>",
             "Jeff Olhoeft <jolhoeft@gmail.com>" ]
 description = "An express.js inspired web framework"
 license = "MIT"
-edition = "2018"
+edition = "2021"
 homepage = "http://nickel-org.github.io/"
 repository = "https://github.com/nickel-org/nickel.rs"
 readme = "README.md"
@@ -25,17 +25,17 @@ futures = "0.3"
 futures-util = { version = "0.3", default-features = false }
 groupable = "0.2"
 hyper = { version = "0.14", features = ["full"] }
-lazy_static = "1.0"
+lazy_static = "1.4"
 log = "0.4"
 mime = "0.3"
 modifier = "0.1"
 mustache = "0.9"
 plugin = "0.2"
-regex = "1.0"
+regex = "1.5"
 serde = "1.0"
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }
-tokio-util = { version = "0.6", features = ["codec"] }
+tokio-util = { version = "0.7", features = ["codec"] }
 typemap = "0.3"
 url = "2"
 


### PR DESCRIPTION
I was unable to create an example on the latest version of Rust.
Now everything works fine (tests and examples) and is up to date.